### PR TITLE
Extract iam.createRole from deploy.js

### DIFF
--- a/bin/deploy.js
+++ b/bin/deploy.js
@@ -8,6 +8,7 @@ const attachPolicies = require("../src/aws/attachPolicies");
 const generateRoleParams = require('../src/aws/generateRoleParams');
 const generateMultipleFunctionParams = require('../src/aws/generateMultipleFunctionParams');
 const generateStateMachineParams = require('../src/aws/generateStateMachineParams');
+const createIAMRole = require('../src/aws/createIAMRole');
 const createLambdaFunctions = require('../src/aws/createLambdaFunctions');
 const createStepFunction = require('../src/aws/createStepFunction');
 // TODO: Separate the retrieving of file basenames and creating zip buffers
@@ -16,9 +17,9 @@ const basenamesAndZipBuffers = getBasenamesAndZipBuffers('lambdas');
 const { lambdaRoleName, statesRoleName } = require('../src/config/roleNames');
 const stateMachineName = process.argv[2] || 'example-workflow'; // TODO: perhaps throw an error?
 
-iam
-  .createRole(generateRoleParams(lambdaRoleName))
-  .promise()
+// Create a new function that returns a promise that encapsulates iam.createRole
+// it will take a role name as an argument
+createIAMRole(lambdaRoleName)
   .then(() => console.log("Successfully created lambda role"))
   .then(() => attachPolicies(lambdaPolicyArns, lambdaRoleName))
   .then(() => console.log("Successfully attached policies"))
@@ -28,9 +29,7 @@ iam
   .then(createLambdaFunctions)
   .then(() => console.log("Successfully created function(s)"));
 
-iam
-  .createRole(generateRoleParams(statesRoleName))
-  .promise()
+createIAMRole(statesRoleName)
   .then(() => console.log("Successfully created state machine role"))
   .then(() => attachPolicies(statesPolicyArns, statesRoleName))
   .then(() => console.log("Successfully attached policies"))

--- a/src/aws/createIAMRole.js
+++ b/src/aws/createIAMRole.js
@@ -1,0 +1,8 @@
+const { iam } = require("./services");
+const generateRoleParams = require("./generateRoleParams");
+
+const createIAMRole = (roleName) => {
+  return iam.createRole(generateRoleParams(roleName)).promise();
+};
+
+module.exports = createIAMRole;


### PR DESCRIPTION
Create a new function in `src/aws/createIAMRole` to be referenced in `deploy.js` instead of calling `iam.createRole` directly. Fixes #10 .