### PR TITLE
Sleep create lambdas

### DIFF
--- a/bin/deploy.js
+++ b/bin/deploy.js
@@ -4,6 +4,7 @@ const { iam, lambda, stepFunctions } = require("../src/aws/services");
 // TODO: determine how to implement ../src/util/requireJSON.js
 const { lambdaPolicyArns, statesPolicyArns } = require("../src/config/policy-arn");
 const getBasenamesAndZipBuffers = require("../src/util/getBasenamesAndZipBuffers");
+const sleep = require("../src/util/sleep");
 const attachPolicies = require("../src/aws/attachPolicies");
 const generateRoleParams = require('../src/aws/generateRoleParams');
 const generateMultipleFunctionParams = require('../src/aws/generateMultipleFunctionParams');
@@ -22,6 +23,7 @@ iam
   .then(() => console.log("Successfully created lambda role"))
   .then(() => attachPolicies(lambdaPolicyArns, lambdaRoleName))
   .then(() => console.log("Successfully attached policies"))
+  .then(() => sleep(7000))
   .then(() =>
     generateMultipleFunctionParams(basenamesAndZipBuffers, lambdaRoleName)
   )

--- a/src/aws/createLambdaFunctions.js
+++ b/src/aws/createLambdaFunctions.js
@@ -3,7 +3,7 @@ const { lambda } = require('./services');
 
 const createLambdaFunctions = (allParams) => {
   const createFunctionPromises = allParams.map((params) =>
-    retryAsync(() => lambda.createFunction(params).promise(), 5, 7000, 0.6)
+    retryAsync(() => lambda.createFunction(params).promise(), 5, 3000, 0.6)
   );
 
   return Promise.all(createFunctionPromises);


### PR DESCRIPTION
Added a sleep step in the promise chain prior to generating function parameters and attempting to create functions. There is a 7 second sleep before an initial attempt to create functions. Then, an attempt is made with an initial 3 second retry with a .6 backoff rate. The initial first creation still fails, but a longer initial sleep may be too odd for the user. An attempt to log 'Preparing to deploy lambdas' prior to sleep did not successfully logged to the console; however, due to the parallel creation of the state machine, the log message did not occur in a place relevant to the user. The log could be created in the arrow function to attempt to log in parallel with the sleep. Also, the sleep/retry can be adjusted. Fixes #8 