### PR TITLE
[WIP] Add command line flags to teardown command

### DIFF
--- a/bin/teardown.js
+++ b/bin/teardown.js
@@ -39,28 +39,17 @@ const main = () => {
     .then(() => retryAsync(() => deleteRole(statesRoleName), 5, 7000, .6));
 };
 
+const asyncPromptYesNoAndExec = async (prompt, callback) => {
+  switch ((await promptAsync(prompt, "y", "N")).trim().toLowerCase()) {
+    case "y":
+    case "yes":
+      callback();
+      break;
+  }
+};
+
 if (argv.force || argv.f) {
   main();
 } else {
-  (async function () {
-    switch (
-      (
-        await promptAsync(
-          `Are you sure you want to delete ${stateMachineName}?`,
-          "y",
-          "N"
-        )
-      )
-        .trim()
-        .toLowerCase()
-    ) {
-      case "y":
-      case "yes":
-        main();
-        break;
-      default:
-        console.log("Aborting...");
-        break;
-    }
-  })();
+  asyncPromptYesNoAndExec(`Are you sure you want to delete ${stateMachineName}?`, main);
 }

--- a/bin/teardown.js
+++ b/bin/teardown.js
@@ -39,16 +39,24 @@ const main = () => {
     .then(() => retryAsync(() => deleteRole(statesRoleName), 5, 7000, .6));
 };
 
-(async function() {
-  switch ((await promptAsync(`Are you sure you want to delete ${stateMachineName}? `)).trim()) {
-    case 'y':
-    case 'yes':
-    case 'Y':
-    case 'Yes':
+(async function () {
+  switch (
+    (
+      await promptAsync(
+        `Are you sure you want to delete ${stateMachineName}?`,
+        "y",
+        "N"
+      )
+    )
+      .trim()
+      .toLowerCase()
+  ) {
+    case "y":
+    case "yes":
       main();
       break;
     default:
-      console.log('Aborting...');
+      console.log("Aborting...");
       break;
   }
 })();

--- a/bin/teardown.js
+++ b/bin/teardown.js
@@ -39,24 +39,28 @@ const main = () => {
     .then(() => retryAsync(() => deleteRole(statesRoleName), 5, 7000, .6));
 };
 
-(async function () {
-  switch (
-    (
-      await promptAsync(
-        `Are you sure you want to delete ${stateMachineName}?`,
-        "y",
-        "N"
+if (argv.force || argv.f) {
+  main();
+} else {
+  (async function () {
+    switch (
+      (
+        await promptAsync(
+          `Are you sure you want to delete ${stateMachineName}?`,
+          "y",
+          "N"
+        )
       )
-    )
-      .trim()
-      .toLowerCase()
-  ) {
-    case "y":
-    case "yes":
-      main();
-      break;
-    default:
-      console.log("Aborting...");
-      break;
-  }
-})();
+        .trim()
+        .toLowerCase()
+    ) {
+      case "y":
+      case "yes":
+        main();
+        break;
+      default:
+        console.log("Aborting...");
+        break;
+    }
+  })();
+}

--- a/bin/teardown.js
+++ b/bin/teardown.js
@@ -2,6 +2,7 @@
 
 const fs = require("fs");
 const childProcess = require("child_process");
+const minimist = require('minimist');
 
 const retryAsync = require("../src/util/retryAsync");
 const { lambdaRoleName, statesRoleName } = require("../src/config/roleNames");
@@ -14,7 +15,9 @@ const detachPolicies = require("../src/aws/detachPolicies");
 const getStateMachineArn = require("../src/aws/getStateMachineArn");
 const basename = require("../src/util/basename");
 
-const stateMachineName = process.argv[2];
+const argv = minimist(process.argv.slice(2));
+
+const stateMachineName = argv._[0];
 // TODO: Specify Lambdas prepended by a given workflow name to delete
 const lambdaNames = fs.readdirSync("lambdas").map(basename);
 

--- a/bin/teardown.js
+++ b/bin/teardown.js
@@ -3,7 +3,6 @@
 const fs = require("fs");
 const childProcess = require("child_process");
 const minimist = require('minimist');
-const readline = require('readline');
 
 const retryAsync = require("../src/util/retryAsync");
 const { lambdaRoleName, statesRoleName } = require("../src/config/roleNames");
@@ -15,6 +14,7 @@ const deleteRole = require("../src/aws/deleteRole");
 const detachPolicies = require("../src/aws/detachPolicies");
 const getStateMachineArn = require("../src/aws/getStateMachineArn");
 const basename = require("../src/util/basename");
+const promptAsync = require("../src/util/promptAsync");
 
 const argv = minimist(process.argv.slice(2));
 const stateMachineName = argv._[0];
@@ -25,20 +25,6 @@ const lambdaNames = fs.readdirSync("lambdas").map(basename);
 if (!stateMachineName) {
   throw new Error("State machine name needs to be provided");
 }
-
-const promptAsync = (question) => {
-  const rl = readline.createInterface({
-    output: process.stdout,
-    input: process.stdin,
-  });
-
-  return new Promise((resolve) => {
-    rl.question(question, (result) => {
-      rl.close();
-      resolve(result);
-    });
-  });
-};
 
 const main = () => {
   deleteLambdas(lambdaNames)

--- a/bin/teardown.js
+++ b/bin/teardown.js
@@ -14,7 +14,7 @@ const deleteRole = require("../src/aws/deleteRole");
 const detachPolicies = require("../src/aws/detachPolicies");
 const getStateMachineArn = require("../src/aws/getStateMachineArn");
 const basename = require("../src/util/basename");
-const asyncPromptYesNoAndExec = require("../src/util/asyncPromptYesNoAndExec");
+const promptAsyncYesNoAndExec = require("../src/util/promptAsyncYesNoAndExec");
 
 const argv = minimist(process.argv.slice(2), { boolean: ["f", "force"] });
 const stateMachineName = argv._[0];
@@ -42,5 +42,5 @@ const main = () => {
 if (argv.force || argv.f) {
   main();
 } else {
-  asyncPromptYesNoAndExec(`Are you sure you want to delete ${stateMachineName}?`, main);
+  promptAsyncYesNoAndExec(`Are you sure you want to delete ${stateMachineName}?`, main);
 }

--- a/bin/teardown.js
+++ b/bin/teardown.js
@@ -6,7 +6,6 @@ const minimist = require('minimist');
 
 const retryAsync = require("../src/util/retryAsync");
 const { lambdaRoleName, statesRoleName } = require("../src/config/roleNames");
-const { lambdaPolicyArns, statesPolicyArns } = require("../src/config/policy-arn");
 const { iam, lambda, stepFunctions } = require("../src/aws/services");
 const deleteLambdas = require("../src/aws/deleteLambdas");
 const deleteStateMachine = require("../src/aws/deleteStateMachine");
@@ -16,8 +15,16 @@ const getStateMachineArn = require("../src/aws/getStateMachineArn");
 const basename = require("../src/util/basename");
 const promptAsyncYesNoAndExec = require("../src/util/promptAsyncYesNoAndExec");
 
-const argv = minimist(process.argv.slice(2), { boolean: ["f", "force"] });
+const argv = minimist(process.argv.slice(2), {
+  boolean: ["f", "force"],
+  string: ["roles"],
+  default: {
+    roles: "",
+  },
+});
+
 const stateMachineName = argv._[0];
+const rolesToDelete = argv.roles.split(',');
 
 // TODO: Specify Lambdas prepended by a given workflow name to delete
 const lambdaNames = fs.readdirSync("lambdas").map(basename);

--- a/bin/teardown.js
+++ b/bin/teardown.js
@@ -16,7 +16,7 @@ const getStateMachineArn = require("../src/aws/getStateMachineArn");
 const basename = require("../src/util/basename");
 const promptAsync = require("../src/util/promptAsync");
 
-const argv = minimist(process.argv.slice(2));
+const argv = minimist(process.argv.slice(2), { boolean: ["f", "force"] });
 const stateMachineName = argv._[0];
 
 // TODO: Specify Lambdas prepended by a given workflow name to delete

--- a/bin/teardown.js
+++ b/bin/teardown.js
@@ -14,7 +14,7 @@ const deleteRole = require("../src/aws/deleteRole");
 const detachPolicies = require("../src/aws/detachPolicies");
 const getStateMachineArn = require("../src/aws/getStateMachineArn");
 const basename = require("../src/util/basename");
-const promptAsync = require("../src/util/promptAsync");
+const asyncPromptYesNoAndExec = require("../src/util/asyncPromptYesNoAndExec");
 
 const argv = minimist(process.argv.slice(2), { boolean: ["f", "force"] });
 const stateMachineName = argv._[0];
@@ -37,15 +37,6 @@ const main = () => {
     .then(deleteStateMachine)
     .then(() => detachPolicies(statesPolicyArns, statesRoleName))
     .then(() => retryAsync(() => deleteRole(statesRoleName), 5, 7000, .6));
-};
-
-const asyncPromptYesNoAndExec = async (prompt, callback) => {
-  switch ((await promptAsync(prompt, "y", "N")).trim().toLowerCase()) {
-    case "y":
-    case "yes":
-      callback();
-      break;
-  }
 };
 
 if (argv.force || argv.f) {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "dependencies": {
-    "aws-sdk": "^2.724.0"
+    "aws-sdk": "^2.724.0",
+    "minimist": "^1.2.5"
   }
 }

--- a/src/aws/getPolicyArnsByRoleName.js
+++ b/src/aws/getPolicyArnsByRoleName.js
@@ -1,0 +1,37 @@
+const { iam } = require("./services");
+
+/*
+
+FIXME: Because iam.listRolePolicies doesn't return the policies that are
+attatched to a role, this doesn't work. Somehow we need to find the policies
+that are attached to the role. How we do that, I'm not too sure, but it needs
+to be done. This currently returns an empty array.
+
+*/
+
+const getPolicyArnsByRoleName = async (name) => {
+  const policyNamesSet = new Set();
+  const allPoliciesPromise = iam.listPolicies().promise();
+  const rolePoliciesPromise = iam
+    .listRolePolicies({ RoleName: name })
+    .promise();
+
+  // Use await Promise.all rather than do each individually, one per line.
+  // This is because it's faster to do requests in parallel rather than serial.
+  const [
+    { Policies: allPolicies },
+    { PolicyNames: policyNames },
+  ] = await Promise.all([allPoliciesPromise, rolePoliciesPromise]);
+
+  policyNames.forEach((name) => policyNamesSet.add(name));
+
+  const matchingPolicies = allPolicies.filter(({ PolicyName: name }) =>
+    policyNamesSet.has(name)
+  );
+
+  const policyArns = matchingPolicies.map(({ Arn: arn }) => arn);
+
+  return policyArns;
+};
+
+module.exports = getPolicyArnsByRoleName;

--- a/src/util/asyncPromptYesNoAndExec.js
+++ b/src/util/asyncPromptYesNoAndExec.js
@@ -1,0 +1,12 @@
+const promptAsync = require('./promptAsync');
+
+const asyncPromptYesNoAndExec = async (prompt, callback) => {
+  switch ((await promptAsync(prompt, "y", "N")).trim().toLowerCase()) {
+    case "y":
+    case "yes":
+      callback();
+      break;
+  }
+};
+
+module.exports = asyncPromptYesNoAndExec;

--- a/src/util/promptAsync.js
+++ b/src/util/promptAsync.js
@@ -1,13 +1,15 @@
 const readline = require('readline');
 
-const promptAsync = (question) => {
+const promptAsync = (question, ...options) => {
   const rl = readline.createInterface({
     output: process.stdout,
     input: process.stdin,
   });
 
+  let prompt = `${question}${options.length > 0 ? ' [' + options.join('/') + ']' : ''} `;
+
   return new Promise((resolve) => {
-    rl.question(question, (result) => {
+    rl.question(prompt, (result) => {
       rl.close();
       resolve(result);
     });

--- a/src/util/promptAsync.js
+++ b/src/util/promptAsync.js
@@ -1,0 +1,17 @@
+const readline = require('readline');
+
+const promptAsync = (question) => {
+  const rl = readline.createInterface({
+    output: process.stdout,
+    input: process.stdin,
+  });
+
+  return new Promise((resolve) => {
+    rl.question(question, (result) => {
+      rl.close();
+      resolve(result);
+    });
+  });
+};
+
+module.exports = promptAsync;

--- a/src/util/promptAsyncYesNoAndExec.js
+++ b/src/util/promptAsyncYesNoAndExec.js
@@ -1,6 +1,6 @@
 const promptAsync = require('./promptAsync');
 
-const asyncPromptYesNoAndExec = async (prompt, callback) => {
+const promptAsyncYesNoAndExec = async (prompt, callback) => {
   switch ((await promptAsync(prompt, "y", "N")).trim().toLowerCase()) {
     case "y":
     case "yes":
@@ -9,4 +9,4 @@ const asyncPromptYesNoAndExec = async (prompt, callback) => {
   }
 };
 
-module.exports = asyncPromptYesNoAndExec;
+module.exports = promptAsyncYesNoAndExec;


### PR DESCRIPTION
With the changes that this PR introduces, one can provide the `-f` or `--force` boolean flags to the teardown command to bypass the confirmation prompt. One can also provide a `--roles` flag that will specify which IAM roles to also delete, in the form of
`--roles=<role1>,<role2>`. Right now, the `--roles` flag is still a WIP and shouldn't be considered ready for review

This PR fixes #17 and #14.