### PR TITLE
Read in `region` variable from config file

### DIFF
--- a/src/aws/services.js
+++ b/src/aws/services.js
@@ -1,7 +1,9 @@
+const fs = require('fs');
+const homedir = require('os').homedir();
 const AWS = require("aws-sdk");
 AWS.config.logger = console;
 const iam = new AWS.IAM();
-const region = "us-west-2";
+const region = JSON.parse(fs.readFileSync(homedir + '/.config/maestro/aws_account_info.json')).region;
 const apiVersion = "latest";
 const lambda = new AWS.Lambda({ apiVersion, region });
 const stepFunctions = new AWS.StepFunctions({ apiVersion, region });


### PR DESCRIPTION
The `region` variable in `src/aws/services.js` is now read in from `~/.config/maestro/aws_account_info.json` using `os` to determine the home directory. This fixes #28 