### PR TITLE
Dynamically generate state machine

### DIFF
--- a/src/aws/generateStateMachineParams.js
+++ b/src/aws/generateStateMachineParams.js
@@ -1,11 +1,22 @@
 const { iam } = require('./services');
 const fs = require("fs");
+const os = require('os');
+const account_info_path = '/.config/maestro/aws_account_info.json';
+
+const retrieveRegion = (path) => {
+  const homedir = os.homedir();
+  const configFile = JSON.parse(fs.readFileSync(homedir + path));
+
+  return configFile.region;
+}
 
 const generateStateMachineParams = async (roleName, stateMachineName) => {
   const role = await iam.getRole({ RoleName: roleName }).promise();
   const definition = fs
     .readFileSync(`state-machines/${stateMachineName}.asl.json`)
     .toString();
+
+  definition.replace()
 
   return {
     definition,

--- a/src/aws/generateStateMachineParams.js
+++ b/src/aws/generateStateMachineParams.js
@@ -3,7 +3,7 @@ const fs = require("fs");
 const os = require('os');
 const account_info_path = '/.config/maestro/aws_account_info.json';
 
-const retrieveRegion = (path) => {
+const readRegionFromFile = (path) => {
   const homedir = os.homedir();
   const configFile = JSON.parse(fs.readFileSync(homedir + path));
 

--- a/src/aws/generateStateMachineParams.js
+++ b/src/aws/generateStateMachineParams.js
@@ -15,16 +15,11 @@ const readStateMachineDefinition = (stateMachineName) => {
     .readFileSync(`state-machines/${stateMachineName}.asl.json`)
     .toString();
 
-  console.log('Definition: ', definition);
-
   return definition;
 };
 
 const replacePlaceholdersInDefinition = (definition, stateMachineName) => {
   const { region, account_number } = readConfigFileFromHome(account_info_path);
-
-  console.log('Region: ', region);
-  console.log('Account Number: ', account_number);
 
   definition = definition.replace(/REGION/g, region);
   definition = definition.replace(/ACCOUNT_ID/g, account_number);
@@ -39,8 +34,6 @@ const generateStateMachineParams = async (roleName, stateMachineName) => {
     readStateMachineDefinition(stateMachineName),
     stateMachineName
   );
-
-  console.log("Definition with replacements: ", definition);
 
   return {
     definition,

--- a/src/aws/generateStateMachineParams.js
+++ b/src/aws/generateStateMachineParams.js
@@ -1,22 +1,26 @@
-const { iam } = require('./services');
+const { iam } = require("./services");
 const fs = require("fs");
-const os = require('os');
-const account_info_path = '/.config/maestro/aws_account_info.json';
+const os = require("os");
+const account_info_path = "/.config/maestro/aws_account_info.json";
 
-const readRegionFromFile = (path) => {
+const readConfigFileFromHome = (path) => {
   const homedir = os.homedir();
   const configFile = JSON.parse(fs.readFileSync(homedir + path));
 
-  return configFile.region;
-}
+  return configFile;
+};
 
-const generateStateMachineParams = async (roleName, stateMachineName) => {
-  const role = await iam.getRole({ RoleName: roleName }).promise();
+const readStateMachineDefinition = (stateMachineName) => {
   const definition = fs
     .readFileSync(`state-machines/${stateMachineName}.asl.json`)
     .toString();
 
-  definition.replace()
+  return definition;
+};
+
+const generateStateMachineParams = async (roleName, stateMachineName) => {
+  const role = await iam.getRole({ RoleName: roleName }).promise();
+  const definition = readStateMachineDefinition(stateMachineName);
 
   return {
     definition,

--- a/src/aws/generateStateMachineParams.js
+++ b/src/aws/generateStateMachineParams.js
@@ -18,7 +18,7 @@ const readStateMachineDefinition = (stateMachineName) => {
   return definition;
 };
 
-const replacePlaceHoldersInStateMachineDefinition = (definition, stateMachineName) => {
+const replacePlaceholdersInDefinition = (definition, stateMachineName) => {
   const { region, account_number } = readConfigFileFromHome(account_info_path);
 
   definition = definition.replaceAll("REGION", region);
@@ -30,7 +30,10 @@ const replacePlaceHoldersInStateMachineDefinition = (definition, stateMachineNam
 
 const generateStateMachineParams = async (roleName, stateMachineName) => {
   const role = await iam.getRole({ RoleName: roleName }).promise();
-  const definition = readStateMachineDefinition(stateMachineName);
+  const definition = replacePlaceholdersInDefinition(
+    readStateMachineDefinition(stateMachineName),
+    stateMachineName
+  );
 
   return {
     definition,

--- a/src/aws/generateStateMachineParams.js
+++ b/src/aws/generateStateMachineParams.js
@@ -20,12 +20,13 @@ const readStateMachineDefinition = (stateMachineName) => {
 
 const replacePlaceholdersInDefinition = (definition, stateMachineName) => {
   const { region, account_number } = readConfigFileFromHome(account_info_path);
+  let modifiedDefinition = definition;
 
-  definition = definition.replace(/REGION/g, region);
-  definition = definition.replace(/ACCOUNT_ID/g, account_number);
-  definition = definition.replace(/WORKFLOW_NAME/g, stateMachineName);
+  modifiedDefinition = modifiedDefinition.replace(/REGION/g, region);
+  modifiedDefinition = modifiedDefinition.replace(/ACCOUNT_ID/g, account_number);
+  modifiedDefinition = modifiedDefinition.replace(/WORKFLOW_NAME/g, stateMachineName);
 
-  return definition;
+  return modifiedDefinition;
 };
 
 const generateStateMachineParams = async (roleName, stateMachineName) => {

--- a/src/aws/generateStateMachineParams.js
+++ b/src/aws/generateStateMachineParams.js
@@ -24,7 +24,10 @@ const replacePlaceholdersInDefinition = (definition, stateMachineName) => {
 
   modifiedDefinition = modifiedDefinition.replace(/REGION/g, region);
   modifiedDefinition = modifiedDefinition.replace(/ACCOUNT_ID/g, account_number);
-  modifiedDefinition = modifiedDefinition.replace(/WORKFLOW_NAME/g, stateMachineName);
+  // TODO: replace WORKFLOW_NAME (not WORKFLOW_NAME_) with stateMachineName
+  //       temporarily only removes the placeholder until the lambdas names
+  //       are updated to reflect the name of the workflow
+  modifiedDefinition = modifiedDefinition.replace(/WORKFLOW_NAME_/g, '');
 
   return modifiedDefinition;
 };

--- a/src/aws/generateStateMachineParams.js
+++ b/src/aws/generateStateMachineParams.js
@@ -15,15 +15,20 @@ const readStateMachineDefinition = (stateMachineName) => {
     .readFileSync(`state-machines/${stateMachineName}.asl.json`)
     .toString();
 
+  console.log('Definition: ', definition);
+
   return definition;
 };
 
 const replacePlaceholdersInDefinition = (definition, stateMachineName) => {
   const { region, account_number } = readConfigFileFromHome(account_info_path);
 
-  definition = definition.replaceAll("REGION", region);
-  definition = definition.replaceAll("ACCOUNT_ID", account_number);
-  definition = definition.replaceAll("WORKFLOW_NAME", stateMachineName);
+  console.log('Region: ', region);
+  console.log('Account Number: ', account_number);
+
+  definition = definition.replace(/REGION/g, region);
+  definition = definition.replace(/ACCOUNT_ID/g, account_number);
+  definition = definition.replace(/WORKFLOW_NAME/g, stateMachineName);
 
   return definition;
 };
@@ -34,6 +39,8 @@ const generateStateMachineParams = async (roleName, stateMachineName) => {
     readStateMachineDefinition(stateMachineName),
     stateMachineName
   );
+
+  console.log("Definition with replacements: ", definition);
 
   return {
     definition,

--- a/src/aws/generateStateMachineParams.js
+++ b/src/aws/generateStateMachineParams.js
@@ -18,16 +18,15 @@ const readStateMachineDefinition = (stateMachineName) => {
   return definition;
 };
 
-const replacePlaceHoldersInStateMachineDefinition = (stateMachineName) => {
+const replacePlaceHoldersInStateMachineDefinition = (definition, stateMachineName) => {
   const { region, account_number } = readConfigFileFromHome(account_info_path);
-  let definition = readStateMachineDefinition(stateMachineName);
 
-  definition = definition.replaceAll('REGION', region);
-  definition = definition.replaceAll('ACCOUNT_NUMBER', account_number);
-  definition = definition.replaceAll('WORKFLOW_NAME', stateMachineName);
+  definition = definition.replaceAll("REGION", region);
+  definition = definition.replaceAll("ACCOUNT_ID", account_number);
+  definition = definition.replaceAll("WORKFLOW_NAME", stateMachineName);
 
   return definition;
-}
+};
 
 const generateStateMachineParams = async (roleName, stateMachineName) => {
   const role = await iam.getRole({ RoleName: roleName }).promise();

--- a/src/aws/generateStateMachineParams.js
+++ b/src/aws/generateStateMachineParams.js
@@ -18,6 +18,17 @@ const readStateMachineDefinition = (stateMachineName) => {
   return definition;
 };
 
+const replacePlaceHoldersInStateMachineDefinition = (stateMachineName) => {
+  const { region, account_number } = readConfigFileFromHome(account_info_path);
+  let definition = readStateMachineDefinition(stateMachineName);
+
+  definition = definition.replaceAll('REGION', region);
+  definition = definition.replaceAll('ACCOUNT_NUMBER', account_number);
+  definition = definition.replaceAll('WORKFLOW_NAME', stateMachineName);
+
+  return definition;
+}
+
 const generateStateMachineParams = async (roleName, stateMachineName) => {
   const role = await iam.getRole({ RoleName: roleName }).promise();
   const definition = readStateMachineDefinition(stateMachineName);

--- a/state-machines/example-workflow.asl.json
+++ b/state-machines/example-workflow.asl.json
@@ -4,12 +4,12 @@
   "States": {
     "Requester": {
       "Type": "Task",
-      "Resource": "arn:aws:lambda:us-west-2:726360710446:function:requester",
+      "Resource": "arn:aws:lambda:REGION:ACCOUNT_ID:function:WORKFLOW_NAME_requester",
       "Next": "Validator"
     },
     "Validator": {
       "Type": "Task",
-      "Resource": "arn:aws:lambda:us-west-2:726360710446:function:validator",
+      "Resource": "arn:aws:lambda:REGION:ACCOUNT_ID:function:WORKFLOW_NAME_validator",
       "Next": "Manager",
       "Catch": [
         {
@@ -21,7 +21,7 @@
     },
     "Manager": {
       "Type": "Task",
-      "Resource": "arn:aws:lambda:us-west-2:726360710446:function:manager",
+      "Resource": "arn:aws:lambda:REGION:ACCOUNT_ID:function:WORKFLOW_NAME_manager",
       "Next": "ManagerChoice"
     },
     "ManagerChoice": {
@@ -37,7 +37,7 @@
     },
     "Provisioner": {
       "Type": "Task",
-      "Resource": "arn:aws:lambda:us-west-2:726360710446:function:provisioner",
+      "Resource": "arn:aws:lambda:REGION:ACCOUNT_ID:function:WORKFLOW_NAME_provisioner",
       "Next": "AccessGranter",
       "Retry": [
         {


### PR DESCRIPTION
Fixes #16 . The state machine 'example-workflow' was modified to no longer have hard coded region and account numbers. It was also modified to prepend a workflow name.

`generateStateMachineParams` was modified to read in the local config file containing region and account info and replace the placeholders in the state definition it reads in.

The code in `src/aws/generateStateMachineParams` was modularized by extracting reading in config file, reading in state machine definition, replacing placeholders to their own functions.

NOTE: the state machine deployed will run!! However, this is because the `WORKFLOW_NAME_` in the ASL of the state function definition is temporarily replaced with an empty string. This is because the lambdas that are deployed have not yet been name-spaced to match the workflow they are deployed with, so a new issue will need to be opened to address this. For the time being, a TODO has been left in the replacement function noting the needed update.