### PR TITLE
Get workflow name from `process.cwd`

### DIFF
--- a/bin/deploy.js
+++ b/bin/deploy.js
@@ -1,6 +1,5 @@
 #!/usr/bin/env node
 
-// TODO: determine how to implement ../src/util/requireJSON.js
 const getBasenamesAndZipBuffers = require("../src/util/getBasenamesAndZipBuffers");
 const generateMultipleFunctionParams = require("../src/aws/generateMultipleFunctionParams");
 const generateStateMachineParams = require("../src/aws/generateStateMachineParams");
@@ -11,7 +10,7 @@ const createStepFunction = require("../src/aws/createStepFunction");
 //   Specify files to retrieve by a workflow name
 const basenamesAndZipBuffers = getBasenamesAndZipBuffers("lambdas");
 const { lambdaRoleName, statesRoleName } = require("../src/config/roleNames");
-const stateMachineName = process.argv[2] || "example-workflow"; // TODO: perhaps throw an error?
+const stateMachineName = require("../src/util/workflowName");
 
 establishIAMRole(lambdaRoleName)
   .then(() =>

--- a/bin/deploy.js
+++ b/bin/deploy.js
@@ -10,7 +10,6 @@ const createStepFunction = require("../src/aws/createStepFunction");
 //   Specify files to retrieve by a workflow name
 const basenamesAndZipBuffers = getBasenamesAndZipBuffers("lambdas");
 const { lambdaRoleName, statesRoleName } = require("../src/config/roleNames");
-const stateMachineName = require("../src/util/workflowName");
 
 establishIAMRole(lambdaRoleName)
   .then(() =>
@@ -20,7 +19,7 @@ establishIAMRole(lambdaRoleName)
   .then(() => console.log("Successfully created function(s)"));
 
 establishIAMRole(statesRoleName)
-  .then(() => generateStateMachineParams(statesRoleName, stateMachineName))
+  .then(() => generateStateMachineParams(statesRoleName))
   .then(createStepFunction)
   .then(() => console.log("Successfully created state machine"))
   .catch(() => {});

--- a/bin/teardown.js
+++ b/bin/teardown.js
@@ -24,12 +24,8 @@ const argv = minimist(process.argv.slice(2), {
     roles: "",
   },
 });
-const stateMachineName = argv._[0];
+const stateMachineName = require("../src/util/workflowName");
 const rolesToDelete = argv.roles.split(",").filter((role) => role.length > 0);
-
-if (!stateMachineName) {
-  throw new Error("State machine name needs to be provided");
-}
 
 // TODO: Specify Lambdas prepended by a given workflow name to delete
 const lambdaNames = fs.readdirSync("lambdas").map(basename);

--- a/src/util/workflowName.js
+++ b/src/util/workflowName.js
@@ -1,2 +1,5 @@
-// This gets the name of the current working directory and removes any preceding path
-module.exports = process.cwd().replace(/\/.*\//, '');
+const cwd = process.cwd();
+const cwdBasename = cwd.replace(/\/.*\//, '')
+const cleanedCwdBasename = cwdBasename.replace(/\W/g, '-');
+
+module.exports = cleanedCwdBasename;

--- a/src/util/workflowName.js
+++ b/src/util/workflowName.js
@@ -1,0 +1,2 @@
+// This gets the name of the current working directory and removes any preceding path
+module.exports = process.cwd().replace(/\/.*\//, '');


### PR DESCRIPTION
This replaces the command line arguments for workflow/project name with a module that can be required as needed