### PR TITLE
Create `new` command to create new Maestro project

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,15 +14,15 @@ To use, you must have the [AWS CLI][aws-cli] installed and set up.
 1. Clone this repository (`git clone https://github.com/maestro-framework/maestro.git /path/to/maestro`)
 2. Install the npm package globally (`sudo npm -g install /path/to/maestro`)
 3. Create a new project with `maestro new [-n|--no-template|-t <template>|--template=<template>|--template <template>] <projectname>`
-6. Create a file called `aws_account_info.json` under `~/.maestro/` that looks like this (change info to your specific needs):
+4. Create a file called `aws_account_info.json` under `~/.maestro/` that looks like this (change info to your specific needs):
    ```
    {
       "account_number": "XXXXXXXXXXXX",
       "region": "XXXXXXXXX"
    }
    ```
-7. Run `maestro deploy` in the top level directory of your Maestro project to deploy it to AWS
-8. To tear down state machine and associated resources, run `maestro teardown [-f|--force|--roles=<roles>|--roles <roles>]`
+5. Run `maestro deploy` in the top level directory of your Maestro project to deploy it to AWS
+6. To tear down state machine and associated resources, run `maestro teardown [-f|--force|--roles=<roles>|--roles <roles>]`
    - This prompts you for confirmation. If you prefer to run it without a confirmation, provide a `-f` or `--force` flag
    - This doesn't automatically tear down the roles that were created upon deployment. To do that, provide a `--roles` flag with a comma-separated-list of role names to tear down (for example, `--roles=roleName1,roleName2` OR `--roles roleName1,roleName2`)
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ To use, you must have the [AWS CLI][aws-cli] installed and set up.
 
 1. Clone this repository (`git clone https://github.com/maestro-framework/maestro.git /path/to/maestro`)
 2. Install the npm package globally (`sudo npm -g install /path/to/maestro`)
-3. Create a new project with `maestro new [-n|--no-template|--template=<template>|--template <template>] <projectname>`
+3. Create a new project with `maestro new [-n|--no-template|-t <template>|--template=<template>|--template <template>] <projectname>`
 6. Create a file called `aws_account_info.json` under `~/.maestro/` that looks like this (change info to your specific needs):
    ```
    {

--- a/README.md
+++ b/README.md
@@ -11,22 +11,20 @@ In the `templates` directory lie an assortment of template Maestro projects to h
 
 To use, you must have the [AWS CLI][aws-cli] installed and set up.
 
-1. Clone this repository (`git clone https://github.com/maestro-framework/maestro.git`)
-2. Change directory into the newly cloned repo (`cd maestro`)
-3. Install npm packages (`npm install`)
-4. Place all lambda files (directories not supported yet) into the `lambdas` directory
-5. Place state machine definition(s) into the `state-machines` directory
-6. Create a file called `aws_account_info.json` under `~/.config/maestro/` that looks like this (change info to your specific needs):
+1. Clone this repository (`git clone https://github.com/maestro-framework/maestro.git /path/to/maestro`)
+2. Install the npm package globally (`sudo npm -g install /path/to/maestro`)
+3. Create a new project with `maestro new [-n|--no-template|--template=<template>|--template <template>] <projectname>`
+6. Create a file called `aws_account_info.json` under `~/.maestro/` that looks like this (change info to your specific needs):
    ```
    {
-      "account_number": "123456789012",
-      "region": "us-east-1"
+      "account_number": "XXXXXXXXXXXX",
+      "region": "XXXXXXXXX"
    }
    ```
-7. Run `deploy.js` in the top level directory of your Maestro project to deploy it to AWS
-8. To tear down state machine and associated resources, run the teardown script in the top level directory of your Maestro project
+7. Run `maestro deploy` in the top level directory of your Maestro project to deploy it to AWS
+8. To tear down state machine and associated resources, run `maestro teardown [-f|--force|--roles=<roles>|--roles <roles>]`
    - This prompts you for confirmation. If you prefer to run it without a confirmation, provide a `-f` or `--force` flag
-   - This doesn't automatically tear down the roles that were created by `deploy.js`. To do that, provide a `--roles` flag with a comma-separated-list of role names to tear down (for example, `--roles=roleName1,roleName2` OR `--roles roleName1,roleName2`)
+   - This doesn't automatically tear down the roles that were created upon deployment. To do that, provide a `--roles` flag with a comma-separated-list of role names to tear down (for example, `--roles=roleName1,roleName2` OR `--roles roleName1,roleName2`)
 
 ## Dependencies
 
@@ -40,7 +38,7 @@ To use, you must have the [AWS CLI][aws-cli] installed and set up.
 ## Development Assumptions
 
 - The name of the workflow is the project directory
-  - The project directory has to have a `lambdas` and `state-machines` child directory (to change soon)
+  - The project directory has to have a `lambdas` subdirectory and a `definition.asl.json` state machine definition template file
 - We'll never deploy or teardown from any location that isn't the project root directory (can't deploy from the lambdas directory or any nested)
 
 [aws-cli]: https://aws.amazon.com/cli/

--- a/bin/maestro.js
+++ b/bin/maestro.js
@@ -10,6 +10,7 @@ const argv = minimist(process.argv.slice(2), {
 });
 const deploy = require('../src/commands/deploy');
 const teardown = require('../src/commands/teardown');
+const newProject = require('../src/commands/newProject');
 
 switch(argv._[0]) {
   case 'deploy':
@@ -17,6 +18,9 @@ switch(argv._[0]) {
     break;
   case 'teardown':
     teardown(argv);
+    break;
+  case 'new':
+    newProject(argv)
     break;
   default:
     console.log(`See documentation for commands (i.e. deploy, teardown).\n https://github.com/maestro-framework/maestro`);

--- a/bin/maestro.js
+++ b/bin/maestro.js
@@ -5,8 +5,12 @@ const teardown = require("../src/commands/teardown");
 const newProject = require("../src/commands/newProject");
 const minimist = require("minimist");
 const argv = minimist(process.argv.slice(2), {
-  boolean: ["f", "force", "n"],
+  boolean: ["force", "n"],
   string: ["roles", "template"],
+  alias: {
+    f: "force",
+    t: "template",
+  },
   default: {
     roles: "",
   },

--- a/bin/maestro.js
+++ b/bin/maestro.js
@@ -8,20 +8,22 @@ const argv = minimist(process.argv.slice(2), {
     roles: "",
   },
 });
-const deploy = require('../src/commands/deploy');
-const teardown = require('../src/commands/teardown');
-const newProject = require('../src/commands/newProject');
+const deploy = require("../src/commands/deploy");
+const teardown = require("../src/commands/teardown");
+const newProject = require("../src/commands/newProject");
 
-switch(argv._[0]) {
-  case 'deploy':
+switch (argv._[0]) {
+  case "deploy":
     deploy();
     break;
-  case 'teardown':
+  case "teardown":
     teardown(argv);
     break;
-  case 'new':
-    newProject(argv)
+  case "new":
+    newProject(argv);
     break;
   default:
-    console.log(`See documentation for commands (i.e. deploy, teardown).\n https://github.com/maestro-framework/maestro`);
+    console.log(
+      `See documentation for commands (i.e. deploy, teardown).\n https://github.com/maestro-framework/maestro`
+    );
 }

--- a/bin/maestro.js
+++ b/bin/maestro.js
@@ -1,16 +1,16 @@
 #!/usr/bin/env node
 
+const deploy = require("../src/commands/deploy");
+const teardown = require("../src/commands/teardown");
+const newProject = require("../src/commands/newProject");
 const minimist = require("minimist");
 const argv = minimist(process.argv.slice(2), {
-  boolean: ["f", "force"],
-  string: ["roles"],
+  boolean: ["f", "force", "n"],
+  string: ["roles", "template"],
   default: {
     roles: "",
   },
 });
-const deploy = require("../src/commands/deploy");
-const teardown = require("../src/commands/teardown");
-const newProject = require("../src/commands/newProject");
 
 switch (argv._[0]) {
   case "deploy":

--- a/src/aws/iam/establishIAMRole.js
+++ b/src/aws/iam/establishIAMRole.js
@@ -1,5 +1,8 @@
 const { iam } = require("../services");
-const { lambdaPolicyArns, statesPolicyArns } = require("../../config/policy-arn");
+const {
+  lambdaPolicyArns,
+  statesPolicyArns,
+} = require("../../config/policy-arn");
 const sleep = require("../../util/sleep");
 const generateRoleParams = require("./generateRoleParams");
 

--- a/src/commands/deploy.js
+++ b/src/commands/deploy.js
@@ -13,10 +13,7 @@ const deploy = () => {
 
   establishIAMRole(lambdaRoleName)
     .then(() =>
-      generateMultipleFunctionParams(
-        basenamesAndZipBuffers,
-        lambdaRoleName
-      )
+      generateMultipleFunctionParams(basenamesAndZipBuffers, lambdaRoleName)
     )
     .then(createLambdaFunctions)
     .then(() => console.log("Successfully created function(s)"));
@@ -26,6 +23,6 @@ const deploy = () => {
     .then(createStepFunction)
     .then(() => console.log("Successfully created state machine"))
     .catch(() => {});
-}
+};
 
 module.exports = deploy;

--- a/src/commands/newProject.js
+++ b/src/commands/newProject.js
@@ -4,6 +4,7 @@ const fs = require("fs");
 const configDir = require("../util/configDir");
 const capitalize = require("../util/capitalize");
 const promptAsync = require("../util/promptAsync");
+const initializeGitRepository = require("../util/initializeGitRepository");
 
 const selectTemplateIdx = async (templateNames) => {
   console.log('Select a template to base your project off of (defaults to no template)');
@@ -25,10 +26,6 @@ const selectTemplateIdx = async (templateNames) => {
 
 const copyTemplateToDir = (templateName, dirname) => {
   childProcess.execSync(`cp -r ${configDir}/templates/${templateName}/* ${dirname}`);
-};
-
-const initializeGitRepository = (dirname) => {
-  childProcess.execSync(`git init ${dirname}`);
 };
 
 const newProject = async (argv) => {

--- a/src/commands/newProject.js
+++ b/src/commands/newProject.js
@@ -13,6 +13,9 @@ const cleanupAndCapitalize = (str) => {
   return capitalize(cleaned);
 };
 
+// TODO: add support for a `--no-template`/`-n` boolean flag
+// and a `--template=`/`--template`/`-t` string flag,
+
 const newProject = async (argv) => {
   const projectName = argv._[1];
 

--- a/src/commands/newProject.js
+++ b/src/commands/newProject.js
@@ -56,11 +56,12 @@ const newProject = async (argv) => {
     selectedTemplate = templateNames[selectedTemplateIdx][1];
 
     console.log(`Creating project based off of template ${cleanSelectedTemplateName}...`);
+
+    copyTemplateToDir(selectedTemplate, projectName);
   } else {
     console.log("Creating project without template...");
   }
 
-  copyTemplateToDir(selectedTemplate, projectName);
   initializeGitRepository(projectName);
 
   console.log(`Created project "${projectName}"!`);

--- a/src/commands/newProject.js
+++ b/src/commands/newProject.js
@@ -1,3 +1,4 @@
+const childProcess = require("child_process");
 const fs = require("fs");
 
 const configDir = require("../util/configDir");
@@ -20,6 +21,10 @@ const selectTemplateIdx = async (templateNames) => {
   } else {
     return selectedIdx;
   }
+};
+
+const copyTemplateToProject = (templateName, projectName) => {
+  childProcess.execSync(`cp -r ${configDir}/templates/${templateName}/* ${projectName}`);
 };
 
 const newProject = async (argv) => {
@@ -56,6 +61,8 @@ const newProject = async (argv) => {
   } else {
     console.log("Creating project without template...");
   }
+
+  copyTemplateToProject(selectedTemplate, projectName);
 
   console.log(`Created project "${projectName}"!`);
 };

--- a/src/commands/newProject.js
+++ b/src/commands/newProject.js
@@ -41,7 +41,7 @@ const newProject = async (argv) => {
 
   // has structure of [["Example workflow", "example-workflow"], ...]
   const templateNames = fs.readdirSync(`${configDir}/templates`).map((name) => {
-    const cleanedName = name.replace(/[-_]/,' ');
+    const cleanedName = name.replace(/[-_]/g,' ');
     return [capitalize(cleanedName), name];
   });
 

--- a/src/commands/newProject.js
+++ b/src/commands/newProject.js
@@ -3,25 +3,14 @@ const fs = require("fs");
 
 const configDir = require("../util/configDir");
 const capitalize = require("../util/capitalize");
-const titleize = require("../util/titleize");
 const initializeGitRepository = require("../util/initializeGitRepository");
 const copyTemplateToDir = require("../util/copyTemplateToDir");
 const selectTemplateIdx = require("../util/selectTemplateIdx");
+const createEmptyProject = require("../util/createEmptyProject");
 
 const cleanupAndCapitalize = (str) => {
   const cleaned = str.replace(/[-_]/g, " ");
   return capitalize(cleaned);
-};
-
-const cleanupAndTitleize = (str) => {
-  const cleaned = str.replace(/[-_]/g, " ");
-  return titleize(cleaned);
-};
-
-const createEmptyProject = (name) => {
-  fs.writeFileSync(`${name}/README.md`, `# ${cleanupAndTitleize(name)}\n\n`);
-  fs.writeFileSync(`${name}/definition.asl.json`, "{}");
-  fs.mkdirSync(`${name}/lambdas`);
 };
 
 const newProject = async (argv) => {

--- a/src/commands/newProject.js
+++ b/src/commands/newProject.js
@@ -5,6 +5,7 @@ const configDir = require("../util/configDir");
 const capitalize = require("../util/capitalize");
 const promptAsync = require("../util/promptAsync");
 const initializeGitRepository = require("../util/initializeGitRepository");
+const copyTemplateToDir = require("../util/copyTemplateToDir");
 
 const selectTemplateIdx = async (templateNames) => {
   console.log('Select a template to base your project off of (defaults to no template)');
@@ -22,10 +23,6 @@ const selectTemplateIdx = async (templateNames) => {
   } else {
     return selectedIdx;
   }
-};
-
-const copyTemplateToDir = (templateName, dirname) => {
-  childProcess.execSync(`cp -r ${configDir}/templates/${templateName}/* ${dirname}`);
 };
 
 const newProject = async (argv) => {

--- a/src/commands/newProject.js
+++ b/src/commands/newProject.js
@@ -25,6 +25,12 @@ const selectTemplateIdx = async (templateNames) => {
   }
 };
 
+const createEmptyProject = (name) => {
+  fs.writeFileSync(`${name}/README.md`,'');
+  fs.writeFileSync(`${name}/definition.asl.json`,'{}');
+  fs.mkdirSync(`${name}/lambdas`);
+};
+
 const newProject = async (argv) => {
   const projectName = argv._[1];
 
@@ -60,6 +66,8 @@ const newProject = async (argv) => {
     copyTemplateToDir(selectedTemplate, projectName);
   } else {
     console.log("Creating project without template...");
+
+    createEmptyProject(projectName);
   }
 
   initializeGitRepository(projectName);

--- a/src/commands/newProject.js
+++ b/src/commands/newProject.js
@@ -1,5 +1,8 @@
 const fs = require("fs");
 
+const configDir = require("../util/configDir");
+const capitalize = require("../util/capitalize");
+
 const newProject = (argv) => {
   const projectName = argv._[1];
 
@@ -16,6 +19,14 @@ const newProject = (argv) => {
     );
     return;
   }
+
+  // has structure of [["Example workflow", "example-workflow"], ...]
+  const templateNames = fs.readdirSync(`${configDir}/templates`).map((name) => {
+    const cleanedName = name.replace(/[-_]/,' ');
+    return [capitalize(cleanedName), name];
+  });
+
+  console.log('Template names:', templateNames);
 
   console.log(`Created project "${projectName}"!`);
 };

--- a/src/commands/newProject.js
+++ b/src/commands/newProject.js
@@ -3,7 +3,8 @@ const fs = require("fs");
 
 const configDir = require("../util/configDir");
 const selectTemplateIdx = require("../util/selectTemplateIdx");
-const cleanupAndCapitalize = require("../util/cleanupAndCapitalize");
+const capitalize = require("../util/capitalize");
+const cleanupProjectName = require("../util/cleanupProjectName");
 const createProjectFromTemplate = require("../util/createProjectFromTemplate");
 const createProjectWithoutTemplate = require("../util/createProjectWithoutTemplate");
 
@@ -33,7 +34,7 @@ const newProject = async (argv) => {
   } else {
     // has structure of [["Example workflow", "example-workflow"], ...]
     const displayTemplateNames = templateNames.map((name) => [
-      cleanupAndCapitalize(name),
+      capitalize(cleanupProjectName(name)),
       name,
     ]);
 

--- a/src/commands/newProject.js
+++ b/src/commands/newProject.js
@@ -13,6 +13,28 @@ const cleanupAndCapitalize = (str) => {
   return capitalize(cleaned);
 };
 
+const createProjectFromTemplate = (projectName, templateName) => {
+  const cleanSelectedTemplateName = cleanupAndCapitalize(templateName);
+
+  console.log(
+    `Creating project based off of template ${cleanSelectedTemplateName}...`
+  );
+
+  copyTemplateToDir(templateName, projectName);
+  initializeGitRepository(projectName);
+
+  console.log(`Created project "${projectName}"!`);
+};
+
+const createProjectWithoutTemplate = (projectName) => {
+  console.log("Creating project without template...");
+
+  createEmptyProject(projectName);
+  initializeGitRepository(projectName);
+
+  console.log(`Created project "${projectName}"!`);
+};
+
 const newProject = async (argv) => {
   const projectName = argv._[1];
 
@@ -33,50 +55,21 @@ const newProject = async (argv) => {
   const templateNames = fs.readdirSync(`${configDir}/templates`);
 
   if (argv.template && templateNames.includes(argv.template)) {
-    const cleanSelectedTemplateName = cleanupAndCapitalize(argv.template);
-
-    console.log(
-      `Creating project based off of template ${cleanSelectedTemplateName}...`
-    );
-
-    copyTemplateToDir(argv.template, projectName);
-    initializeGitRepository(projectName);
-
-    console.log(`Created project "${projectName}"!`);
+    createProjectFromTemplate(projectName, argv.template);
   } else if (argv.n || argv.template === false) {
-    console.log("Creating project without template...");
-
-    createEmptyProject(projectName);
-    initializeGitRepository(projectName);
-
-    console.log(`Created project "${projectName}"!`);
+    createProjectWithoutTemplate(projectName);
   } else {
-    const displayTemplateNames = templateNames.map((name) => {
-      // has structure of [["Example workflow", "example-workflow"], ...]
-      return [cleanupAndCapitalize(name), name];
-    });
+    // has structure of [["Example workflow", "example-workflow"], ...]
+    const displayTemplateNames = templateNames.map((name) => [cleanupAndCapitalize(name), name]);
 
     const selectedTemplateIdx = await selectTemplateIdx(displayTemplateNames);
-    let selectedTemplate;
 
     if (selectedTemplateIdx !== -1) {
-      const cleanSelectedTemplateName = templateNames[selectedTemplateIdx][0];
-      selectedTemplate = templateNames[selectedTemplateIdx][1];
-
-      console.log(
-        `Creating project based off of template ${cleanSelectedTemplateName}...`
-      );
-
-      copyTemplateToDir(selectedTemplate, projectName);
+      const selectedTemplate = displayTemplateNames[selectedTemplateIdx][1];
+      createProjectFromTemplate(projectName, selectedTemplate);
     } else {
-      console.log("Creating project without template...");
-
-      createEmptyProject(projectName);
+      createProjectWithoutTemplate(projectName);
     }
-
-    initializeGitRepository(projectName);
-
-    console.log(`Created project "${projectName}"!`);
   }
 };
 

--- a/src/commands/newProject.js
+++ b/src/commands/newProject.js
@@ -33,6 +33,18 @@ const newProject = async (argv) => {
     return;
   }
 
+  if (argv.n || argv.template === false) {
+    console.log("Creating project without template...");
+
+    createEmptyProject(projectName);
+
+    initializeGitRepository(projectName);
+
+    console.log(`Created project "${projectName}"!`);
+
+    return;
+  }
+
   // has structure of [["Example workflow", "example-workflow"], ...]
   const templateNames = fs.readdirSync(`${configDir}/templates`).map((name) => {
     return [cleanupAndCapitalize(name), name];

--- a/src/commands/newProject.js
+++ b/src/commands/newProject.js
@@ -4,36 +4,9 @@ const fs = require("fs");
 const configDir = require("../util/configDir");
 const capitalize = require("../util/capitalize");
 const titleize = require("../util/titleize");
-const promptAsync = require("../util/promptAsync");
 const initializeGitRepository = require("../util/initializeGitRepository");
 const copyTemplateToDir = require("../util/copyTemplateToDir");
-
-const selectTemplateIdx = async (templateNames) => {
-  console.log(
-    "Select a template to base your project off of (defaults to no template)"
-  );
-  console.log(
-    "-----------------------------------------------------------------------"
-  );
-
-  templateNames.forEach(([prettyName, rawName], idx) => {
-    console.log(`${`[${idx + 1}]`.padStart(5)} ${prettyName} (${rawName})`);
-  });
-
-  console.log(
-    "-----------------------------------------------------------------------"
-  );
-  const selectedIdx =
-    Number(
-      await promptAsync(`Select template 1-${templateNames.length}`, "none")
-    ) - 1;
-
-  if (Number.isNaN(selectedIdx) || !templateNames[selectedIdx]) {
-    return -1;
-  } else {
-    return selectedIdx;
-  }
-};
+const selectTemplateIdx = require("../util/selectTemplateIdx");
 
 const cleanupAndCapitalize = (str) => {
   const cleaned = str.replace(/[-_]/g, " ");

--- a/src/commands/newProject.js
+++ b/src/commands/newProject.js
@@ -2,33 +2,10 @@ const childProcess = require("child_process");
 const fs = require("fs");
 
 const configDir = require("../util/configDir");
-const initializeGitRepository = require("../util/initializeGitRepository");
-const copyTemplateToDir = require("../util/copyTemplateToDir");
 const selectTemplateIdx = require("../util/selectTemplateIdx");
-const createEmptyProject = require("../util/createEmptyProject");
 const cleanupAndCapitalize = require("../util/cleanupAndCapitalize");
-
-const createProjectFromTemplate = (projectName, templateName) => {
-  const cleanSelectedTemplateName = cleanupAndCapitalize(templateName);
-
-  console.log(
-    `Creating project based off of template ${cleanSelectedTemplateName}...`
-  );
-
-  copyTemplateToDir(templateName, projectName);
-  initializeGitRepository(projectName);
-
-  console.log(`Created project "${projectName}"!`);
-};
-
-const createProjectWithoutTemplate = (projectName) => {
-  console.log("Creating project without template...");
-
-  createEmptyProject(projectName);
-  initializeGitRepository(projectName);
-
-  console.log(`Created project "${projectName}"!`);
-};
+const createProjectFromTemplate = require("../util/createProjectFromTemplate");
+const createProjectWithoutTemplate = require("../util/createProjectWithoutTemplate");
 
 const newProject = async (argv) => {
   const projectName = argv._[1];

--- a/src/commands/newProject.js
+++ b/src/commands/newProject.js
@@ -27,6 +27,10 @@ const copyTemplateToProject = (templateName, projectName) => {
   childProcess.execSync(`cp -r ${configDir}/templates/${templateName}/* ${projectName}`);
 };
 
+const initializeProjectGitRepository = (projectName) => {
+  childProcess.execSync(`git init ${projectName}`);
+};
+
 const newProject = async (argv) => {
   const projectName = argv._[1];
 
@@ -63,6 +67,7 @@ const newProject = async (argv) => {
   }
 
   copyTemplateToProject(selectedTemplate, projectName);
+  initializeProjectGitRepository(projectName);
 
   console.log(`Created project "${projectName}"!`);
 };

--- a/src/commands/newProject.js
+++ b/src/commands/newProject.js
@@ -3,6 +3,7 @@ const fs = require("fs");
 
 const configDir = require("../util/configDir");
 const capitalize = require("../util/capitalize");
+const titleize = require("../util/titleize");
 const promptAsync = require("../util/promptAsync");
 const initializeGitRepository = require("../util/initializeGitRepository");
 const copyTemplateToDir = require("../util/copyTemplateToDir");
@@ -34,15 +35,20 @@ const selectTemplateIdx = async (templateNames) => {
   }
 };
 
-const createEmptyProject = (name) => {
-  fs.writeFileSync(`${name}/README.md`, "");
-  fs.writeFileSync(`${name}/definition.asl.json`, "{}");
-  fs.mkdirSync(`${name}/lambdas`);
-};
-
 const cleanupAndCapitalize = (str) => {
   const cleaned = str.replace(/[-_]/g, " ");
   return capitalize(cleaned);
+};
+
+const cleanupAndTitleize = (str) => {
+  const cleaned = str.replace(/[-_]/g, " ");
+  return titleize(cleaned);
+};
+
+const createEmptyProject = (name) => {
+  fs.writeFileSync(`${name}/README.md`, `# ${cleanupAndTitleize(name)}\n`);
+  fs.writeFileSync(`${name}/definition.asl.json`, "{}");
+  fs.mkdirSync(`${name}/lambdas`);
 };
 
 const newProject = async (argv) => {

--- a/src/commands/newProject.js
+++ b/src/commands/newProject.js
@@ -23,12 +23,12 @@ const selectTemplateIdx = async (templateNames) => {
   }
 };
 
-const copyTemplateToProject = (templateName, projectName) => {
-  childProcess.execSync(`cp -r ${configDir}/templates/${templateName}/* ${projectName}`);
+const copyTemplateToDir = (templateName, dirname) => {
+  childProcess.execSync(`cp -r ${configDir}/templates/${templateName}/* ${dirname}`);
 };
 
-const initializeProjectGitRepository = (projectName) => {
-  childProcess.execSync(`git init ${projectName}`);
+const initializeGitRepository = (dirname) => {
+  childProcess.execSync(`git init ${dirname}`);
 };
 
 const newProject = async (argv) => {
@@ -66,8 +66,8 @@ const newProject = async (argv) => {
     console.log("Creating project without template...");
   }
 
-  copyTemplateToProject(selectedTemplate, projectName);
-  initializeProjectGitRepository(projectName);
+  copyTemplateToDir(selectedTemplate, projectName);
+  initializeGitRepository(projectName);
 
   console.log(`Created project "${projectName}"!`);
 };

--- a/src/commands/newProject.js
+++ b/src/commands/newProject.js
@@ -46,7 +46,7 @@ const cleanupAndTitleize = (str) => {
 };
 
 const createEmptyProject = (name) => {
-  fs.writeFileSync(`${name}/README.md`, `# ${cleanupAndTitleize(name)}\n`);
+  fs.writeFileSync(`${name}/README.md`, `# ${cleanupAndTitleize(name)}\n\n`);
   fs.writeFileSync(`${name}/definition.asl.json`, "{}");
   fs.mkdirSync(`${name}/lambdas`);
 };

--- a/src/commands/newProject.js
+++ b/src/commands/newProject.js
@@ -31,6 +31,11 @@ const createEmptyProject = (name) => {
   fs.mkdirSync(`${name}/lambdas`);
 };
 
+const cleanupAndCapitalize = (str) => {
+  const cleaned = str.replace(/[-_]/g,' ');
+  return capitalize(cleaned);
+};
+
 const newProject = async (argv) => {
   const projectName = argv._[1];
 
@@ -50,8 +55,7 @@ const newProject = async (argv) => {
 
   // has structure of [["Example workflow", "example-workflow"], ...]
   const templateNames = fs.readdirSync(`${configDir}/templates`).map((name) => {
-    const cleanedName = name.replace(/[-_]/g,' ');
-    return [capitalize(cleanedName), name];
+    return [cleanupAndCapitalize(name), name];
   });
 
   const selectedTemplateIdx = await selectTemplateIdx(templateNames);

--- a/src/commands/newProject.js
+++ b/src/commands/newProject.js
@@ -2,16 +2,11 @@ const childProcess = require("child_process");
 const fs = require("fs");
 
 const configDir = require("../util/configDir");
-const capitalize = require("../util/capitalize");
 const initializeGitRepository = require("../util/initializeGitRepository");
 const copyTemplateToDir = require("../util/copyTemplateToDir");
 const selectTemplateIdx = require("../util/selectTemplateIdx");
 const createEmptyProject = require("../util/createEmptyProject");
-
-const cleanupAndCapitalize = (str) => {
-  const cleaned = str.replace(/[-_]/g, " ");
-  return capitalize(cleaned);
-};
+const cleanupAndCapitalize = require("../util/cleanupAndCapitalize");
 
 const createProjectFromTemplate = (projectName, templateName) => {
   const cleanSelectedTemplateName = cleanupAndCapitalize(templateName);

--- a/src/commands/newProject.js
+++ b/src/commands/newProject.js
@@ -2,8 +2,27 @@ const fs = require("fs");
 
 const configDir = require("../util/configDir");
 const capitalize = require("../util/capitalize");
+const promptAsync = require("../util/promptAsync");
 
-const newProject = (argv) => {
+const selectTemplateIdx = async (templateNames) => {
+  console.log('Select a template to base your project off of (defaults to no template)');
+  console.log('-----------------------------------------------------------------------');
+
+  templateNames.forEach(([prettyName, rawName], idx) => {
+    console.log(`${`[${idx + 1}]`.padStart(5)} ${prettyName} (${rawName})`);
+  });
+
+  console.log('-----------------------------------------------------------------------');
+  const selectedIdx = Number(await promptAsync(`Select template 1-${templateNames.length}`, 'none')) - 1;
+
+  if (Number.isNaN(selectedIdx) || !templateNames[selectedIdx]) {
+    return -1;
+  } else {
+    return selectedIdx;
+  }
+};
+
+const newProject = async (argv) => {
   const projectName = argv._[1];
 
   if (!projectName) {
@@ -26,7 +45,17 @@ const newProject = (argv) => {
     return [capitalize(cleanedName), name];
   });
 
-  console.log('Template names:', templateNames);
+  const selectedTemplateIdx = await selectTemplateIdx(templateNames);
+  let selectedTemplate;
+
+  if (selectedTemplateIdx !== -1) {
+    const cleanSelectedTemplateName = templateNames[selectedTemplateIdx][0];
+    selectedTemplate = templateNames[selectedTemplateIdx][1];
+
+    console.log(`Creating project based off of template ${cleanSelectedTemplateName}...`);
+  } else {
+    console.log("Creating project without template...");
+  }
 
   console.log(`Created project "${projectName}"!`);
 };

--- a/src/commands/newProject.js
+++ b/src/commands/newProject.js
@@ -32,7 +32,10 @@ const newProject = async (argv) => {
     createProjectWithoutTemplate(projectName);
   } else {
     // has structure of [["Example workflow", "example-workflow"], ...]
-    const displayTemplateNames = templateNames.map((name) => [cleanupAndCapitalize(name), name]);
+    const displayTemplateNames = templateNames.map((name) => [
+      cleanupAndCapitalize(name),
+      name,
+    ]);
 
     const selectedTemplateIdx = await selectTemplateIdx(displayTemplateNames);
 

--- a/src/commands/newProject.js
+++ b/src/commands/newProject.js
@@ -8,15 +8,24 @@ const initializeGitRepository = require("../util/initializeGitRepository");
 const copyTemplateToDir = require("../util/copyTemplateToDir");
 
 const selectTemplateIdx = async (templateNames) => {
-  console.log('Select a template to base your project off of (defaults to no template)');
-  console.log('-----------------------------------------------------------------------');
+  console.log(
+    "Select a template to base your project off of (defaults to no template)"
+  );
+  console.log(
+    "-----------------------------------------------------------------------"
+  );
 
   templateNames.forEach(([prettyName, rawName], idx) => {
     console.log(`${`[${idx + 1}]`.padStart(5)} ${prettyName} (${rawName})`);
   });
 
-  console.log('-----------------------------------------------------------------------');
-  const selectedIdx = Number(await promptAsync(`Select template 1-${templateNames.length}`, 'none')) - 1;
+  console.log(
+    "-----------------------------------------------------------------------"
+  );
+  const selectedIdx =
+    Number(
+      await promptAsync(`Select template 1-${templateNames.length}`, "none")
+    ) - 1;
 
   if (Number.isNaN(selectedIdx) || !templateNames[selectedIdx]) {
     return -1;
@@ -26,13 +35,13 @@ const selectTemplateIdx = async (templateNames) => {
 };
 
 const createEmptyProject = (name) => {
-  fs.writeFileSync(`${name}/README.md`,'');
-  fs.writeFileSync(`${name}/definition.asl.json`,'{}');
+  fs.writeFileSync(`${name}/README.md`, "");
+  fs.writeFileSync(`${name}/definition.asl.json`, "{}");
   fs.mkdirSync(`${name}/lambdas`);
 };
 
 const cleanupAndCapitalize = (str) => {
-  const cleaned = str.replace(/[-_]/g,' ');
+  const cleaned = str.replace(/[-_]/g, " ");
   return capitalize(cleaned);
 };
 
@@ -65,7 +74,9 @@ const newProject = async (argv) => {
     const cleanSelectedTemplateName = templateNames[selectedTemplateIdx][0];
     selectedTemplate = templateNames[selectedTemplateIdx][1];
 
-    console.log(`Creating project based off of template ${cleanSelectedTemplateName}...`);
+    console.log(
+      `Creating project based off of template ${cleanSelectedTemplateName}...`
+    );
 
     copyTemplateToDir(selectedTemplate, projectName);
   } else {

--- a/src/commands/newProject.js
+++ b/src/commands/newProject.js
@@ -1,0 +1,23 @@
+const fs = require("fs");
+
+const newProject = (argv) => {
+  const projectName = argv._[1];
+
+  if (!projectName) {
+    console.log("Please provide a project name");
+    return;
+  }
+
+  try {
+    fs.mkdirSync(projectName);
+  } catch {
+    console.log(
+      `Can't create project with name "${projectName}": directory with same name already exists!`
+    );
+    return;
+  }
+
+  console.log(`Created project "${projectName}"!`);
+};
+
+module.exports = newProject;

--- a/src/commands/newProject.js
+++ b/src/commands/newProject.js
@@ -25,7 +25,18 @@ const newProject = async (argv) => {
     return;
   }
 
-  const templateNames = fs.readdirSync(`${configDir}/templates`);
+  try {
+    const templateNames = fs.readdirSync(`${configDir}/templates`);
+  } catch {
+    console.log(`Warning: the directory "${configDir}/templates" doesn't exist.`);
+    console.log(
+      "If you wish to create a project based off of a template," +
+        " please run the `maestro get-templates` command and try again."
+    );
+
+    createProjectWithoutTemplate(projectName);
+    return;
+  }
 
   if (argv.template && templateNames.includes(argv.template)) {
     createProjectFromTemplate(projectName, argv.template);

--- a/src/commands/newProject.js
+++ b/src/commands/newProject.js
@@ -13,9 +13,6 @@ const cleanupAndCapitalize = (str) => {
   return capitalize(cleaned);
 };
 
-// TODO: add support for a `--no-template`/`-n` boolean flag
-// and a `--template=`/`--template`/`-t` string flag,
-
 const newProject = async (argv) => {
   const projectName = argv._[1];
 
@@ -33,44 +30,54 @@ const newProject = async (argv) => {
     return;
   }
 
-  if (argv.n || argv.template === false) {
-    console.log("Creating project without template...");
+  const templateNames = fs.readdirSync(`${configDir}/templates`);
 
-    createEmptyProject(projectName);
-
-    initializeGitRepository(projectName);
-
-    console.log(`Created project "${projectName}"!`);
-
-    return;
-  }
-
-  // has structure of [["Example workflow", "example-workflow"], ...]
-  const templateNames = fs.readdirSync(`${configDir}/templates`).map((name) => {
-    return [cleanupAndCapitalize(name), name];
-  });
-
-  const selectedTemplateIdx = await selectTemplateIdx(templateNames);
-  let selectedTemplate;
-
-  if (selectedTemplateIdx !== -1) {
-    const cleanSelectedTemplateName = templateNames[selectedTemplateIdx][0];
-    selectedTemplate = templateNames[selectedTemplateIdx][1];
+  if (argv.template && templateNames.includes(argv.template)) {
+    const cleanSelectedTemplateName = cleanupAndCapitalize(argv.template);
 
     console.log(
       `Creating project based off of template ${cleanSelectedTemplateName}...`
     );
 
-    copyTemplateToDir(selectedTemplate, projectName);
-  } else {
+    copyTemplateToDir(argv.template, projectName);
+    initializeGitRepository(projectName);
+
+    console.log(`Created project "${projectName}"!`);
+  } else if (argv.n || argv.template === false) {
     console.log("Creating project without template...");
 
     createEmptyProject(projectName);
+    initializeGitRepository(projectName);
+
+    console.log(`Created project "${projectName}"!`);
+  } else {
+    const displayTemplateNames = templateNames.map((name) => {
+      // has structure of [["Example workflow", "example-workflow"], ...]
+      return [cleanupAndCapitalize(name), name];
+    });
+
+    const selectedTemplateIdx = await selectTemplateIdx(displayTemplateNames);
+    let selectedTemplate;
+
+    if (selectedTemplateIdx !== -1) {
+      const cleanSelectedTemplateName = templateNames[selectedTemplateIdx][0];
+      selectedTemplate = templateNames[selectedTemplateIdx][1];
+
+      console.log(
+        `Creating project based off of template ${cleanSelectedTemplateName}...`
+      );
+
+      copyTemplateToDir(selectedTemplate, projectName);
+    } else {
+      console.log("Creating project without template...");
+
+      createEmptyProject(projectName);
+    }
+
+    initializeGitRepository(projectName);
+
+    console.log(`Created project "${projectName}"!`);
   }
-
-  initializeGitRepository(projectName);
-
-  console.log(`Created project "${projectName}"!`);
 };
 
 module.exports = newProject;

--- a/src/util/capitalize.js
+++ b/src/util/capitalize.js
@@ -1,5 +1,5 @@
 const capitalize = (str) => {
-  if (str === '') return '';
+  if (str === "") return "";
 
   return str[0].toUpperCase() + str.slice(1).toLowerCase();
 };

--- a/src/util/capitalize.js
+++ b/src/util/capitalize.js
@@ -1,0 +1,7 @@
+const capitalize = (str) => {
+  if (str === '') return '';
+
+  return str[0].toUpperCase() + str.slice(1).toLowerCase();
+};
+
+module.exports = capitalize;

--- a/src/util/cleanupAndCapitalize.js
+++ b/src/util/cleanupAndCapitalize.js
@@ -1,0 +1,8 @@
+const capitalize = require("../util/capitalize");
+
+const cleanupAndCapitalize = (str) => {
+  const cleaned = str.replace(/[-_]/g, " ");
+  return capitalize(cleaned);
+};
+
+module.exports = cleanupAndCapitalize;

--- a/src/util/cleanupAndCapitalize.js
+++ b/src/util/cleanupAndCapitalize.js
@@ -1,8 +1,0 @@
-const capitalize = require("../util/capitalize");
-
-const cleanupAndCapitalize = (str) => {
-  const cleaned = str.replace(/[-_]/g, " ");
-  return capitalize(cleaned);
-};
-
-module.exports = cleanupAndCapitalize;

--- a/src/util/cleanupProjectName.js
+++ b/src/util/cleanupProjectName.js
@@ -1,0 +1,1 @@
+module.exports = (name) => name.replace(/[-_]/g, " ");

--- a/src/util/configDir.js
+++ b/src/util/configDir.js
@@ -1,5 +1,5 @@
-const os = require('os');
+const os = require("os");
 const homedir = os.homedir();
-const configDir = '.maestro';
+const configDir = ".maestro";
 
 module.exports = `${homedir}/${configDir}`;

--- a/src/util/configDir.js
+++ b/src/util/configDir.js
@@ -1,0 +1,5 @@
+const os = require('os');
+const homedir = os.homedir();
+const configDir = '.maestro';
+
+module.exports = `${homedir}/${configDir}`;

--- a/src/util/copyTemplateToDir.js
+++ b/src/util/copyTemplateToDir.js
@@ -1,5 +1,5 @@
 const childProcess = require("child_process");
-const configDir = require("../util/configDir");
+const configDir = require("./configDir");
 
 const copyTemplateToDir = (templateName, dirname) => {
   childProcess.execSync(

--- a/src/util/copyTemplateToDir.js
+++ b/src/util/copyTemplateToDir.js
@@ -2,7 +2,9 @@ const childProcess = require("child_process");
 const configDir = require("../util/configDir");
 
 const copyTemplateToDir = (templateName, dirname) => {
-  childProcess.execSync(`cp -r ${configDir}/templates/${templateName}/* ${dirname}`);
+  childProcess.execSync(
+    `cp -r ${configDir}/templates/${templateName}/* ${dirname}`
+  );
 };
 
 module.exports = copyTemplateToDir;

--- a/src/util/copyTemplateToDir.js
+++ b/src/util/copyTemplateToDir.js
@@ -1,0 +1,8 @@
+const childProcess = require("child_process");
+const configDir = require("../util/configDir");
+
+const copyTemplateToDir = (templateName, dirname) => {
+  childProcess.execSync(`cp -r ${configDir}/templates/${templateName}/* ${dirname}`);
+};
+
+module.exports = copyTemplateToDir;

--- a/src/util/createEmptyProject.js
+++ b/src/util/createEmptyProject.js
@@ -1,0 +1,15 @@
+const fs = require("fs");
+const titleize = require("../util/titleize");
+
+const cleanupAndTitleize = (str) => {
+  const cleaned = str.replace(/[-_]/g, " ");
+  return titleize(cleaned);
+};
+
+const createEmptyProject = (name) => {
+  fs.writeFileSync(`${name}/README.md`, `# ${cleanupAndTitleize(name)}\n\n`);
+  fs.writeFileSync(`${name}/definition.asl.json`, "{}");
+  fs.mkdirSync(`${name}/lambdas`);
+};
+
+module.exports = createEmptyProject;

--- a/src/util/createEmptyProject.js
+++ b/src/util/createEmptyProject.js
@@ -1,13 +1,9 @@
 const fs = require("fs");
 const titleize = require("../util/titleize");
-
-const cleanupAndTitleize = (str) => {
-  const cleaned = str.replace(/[-_]/g, " ");
-  return titleize(cleaned);
-};
+const cleanupProjectName = require("../util/cleanupProjectName");
 
 const createEmptyProject = (name) => {
-  fs.writeFileSync(`${name}/README.md`, `# ${cleanupAndTitleize(name)}\n\n`);
+  fs.writeFileSync(`${name}/README.md`, `# ${titleize(cleanupProjectName(name))}\n\n`);
   fs.writeFileSync(`${name}/definition.asl.json`, "{}");
   fs.mkdirSync(`${name}/lambdas`);
 };

--- a/src/util/createEmptyProject.js
+++ b/src/util/createEmptyProject.js
@@ -1,9 +1,12 @@
 const fs = require("fs");
-const titleize = require("../util/titleize");
-const cleanupProjectName = require("../util/cleanupProjectName");
+const titleize = require("./titleize");
+const cleanupProjectName = require("./cleanupProjectName");
 
 const createEmptyProject = (name) => {
-  fs.writeFileSync(`${name}/README.md`, `# ${titleize(cleanupProjectName(name))}\n\n`);
+  fs.writeFileSync(
+    `${name}/README.md`,
+    `# ${titleize(cleanupProjectName(name))}\n\n`
+  );
   fs.writeFileSync(`${name}/definition.asl.json`, "{}");
   fs.mkdirSync(`${name}/lambdas`);
 };

--- a/src/util/createProjectFromTemplate.js
+++ b/src/util/createProjectFromTemplate.js
@@ -1,10 +1,12 @@
-const initializeGitRepository = require("../util/initializeGitRepository");
-const copyTemplateToDir = require("../util/copyTemplateToDir");
-const capitalize = require("../util/capitalize");
-const cleanupProjectName = require("../util/cleanupProjectName");
+const initializeGitRepository = require("./initializeGitRepository");
+const copyTemplateToDir = require("./copyTemplateToDir");
+const capitalize = require("./capitalize");
+const cleanupProjectName = require("./cleanupProjectName");
 
 const createProjectFromTemplate = (projectName, templateName) => {
-  const cleanSelectedTemplateName = capitalize(cleanupProjectName(templateName));
+  const cleanSelectedTemplateName = capitalize(
+    cleanupProjectName(templateName)
+  );
 
   console.log(
     `Creating project based off of template ${cleanSelectedTemplateName}...`

--- a/src/util/createProjectFromTemplate.js
+++ b/src/util/createProjectFromTemplate.js
@@ -1,0 +1,18 @@
+const initializeGitRepository = require("../util/initializeGitRepository");
+const copyTemplateToDir = require("../util/copyTemplateToDir");
+const cleanupAndCapitalize = require("../util/cleanupAndCapitalize");
+
+const createProjectFromTemplate = (projectName, templateName) => {
+  const cleanSelectedTemplateName = cleanupAndCapitalize(templateName);
+
+  console.log(
+    `Creating project based off of template ${cleanSelectedTemplateName}...`
+  );
+
+  copyTemplateToDir(templateName, projectName);
+  initializeGitRepository(projectName);
+
+  console.log(`Created project "${projectName}"!`);
+};
+
+module.exports = createProjectFromTemplate;

--- a/src/util/createProjectFromTemplate.js
+++ b/src/util/createProjectFromTemplate.js
@@ -1,9 +1,10 @@
 const initializeGitRepository = require("../util/initializeGitRepository");
 const copyTemplateToDir = require("../util/copyTemplateToDir");
-const cleanupAndCapitalize = require("../util/cleanupAndCapitalize");
+const capitalize = require("../util/capitalize");
+const cleanupProjectName = require("../util/cleanupProjectName");
 
 const createProjectFromTemplate = (projectName, templateName) => {
-  const cleanSelectedTemplateName = cleanupAndCapitalize(templateName);
+  const cleanSelectedTemplateName = capitalize(cleanupProjectName(templateName));
 
   console.log(
     `Creating project based off of template ${cleanSelectedTemplateName}...`

--- a/src/util/createProjectWithoutTemplate.js
+++ b/src/util/createProjectWithoutTemplate.js
@@ -1,5 +1,5 @@
-const initializeGitRepository = require("../util/initializeGitRepository");
-const createEmptyProject = require("../util/createEmptyProject");
+const initializeGitRepository = require("./initializeGitRepository");
+const createEmptyProject = require("./createEmptyProject");
 
 const createProjectWithoutTemplate = (projectName) => {
   console.log("Creating project without template...");

--- a/src/util/createProjectWithoutTemplate.js
+++ b/src/util/createProjectWithoutTemplate.js
@@ -1,0 +1,13 @@
+const initializeGitRepository = require("../util/initializeGitRepository");
+const createEmptyProject = require("../util/createEmptyProject");
+
+const createProjectWithoutTemplate = (projectName) => {
+  console.log("Creating project without template...");
+
+  createEmptyProject(projectName);
+  initializeGitRepository(projectName);
+
+  console.log(`Created project "${projectName}"!`);
+};
+
+module.exports = createProjectWithoutTemplate;

--- a/src/util/initializeGitRepository.js
+++ b/src/util/initializeGitRepository.js
@@ -1,7 +1,7 @@
 const childProcess = require("child_process");
 
 const initializeGitRepository = (dirname) => {
-  childProcess.execSync(`git init ${dirname}`);
+  childProcess.execSync(`git init '${dirname}'`);
 };
 
 module.exports = initializeGitRepository;

--- a/src/util/initializeGitRepository.js
+++ b/src/util/initializeGitRepository.js
@@ -1,0 +1,7 @@
+const childProcess = require("child_process");
+
+const initializeGitRepository = (dirname) => {
+  childProcess.execSync(`git init ${dirname}`);
+};
+
+module.exports = initializeGitRepository;

--- a/src/util/selectTemplateIdx.js
+++ b/src/util/selectTemplateIdx.js
@@ -1,4 +1,4 @@
-const promptAsync = require("../util/promptAsync");
+const promptAsync = require("./promptAsync");
 
 const selectTemplateIdx = async (templateNames) => {
   console.log(

--- a/src/util/selectTemplateIdx.js
+++ b/src/util/selectTemplateIdx.js
@@ -1,0 +1,30 @@
+const promptAsync = require("../util/promptAsync");
+
+const selectTemplateIdx = async (templateNames) => {
+  console.log(
+    "Select a template to base your project off of (defaults to no template)"
+  );
+  console.log(
+    "-----------------------------------------------------------------------"
+  );
+
+  templateNames.forEach(([prettyName, rawName], idx) => {
+    console.log(`${`[${idx + 1}]`.padStart(5)} ${prettyName} (${rawName})`);
+  });
+
+  console.log(
+    "-----------------------------------------------------------------------"
+  );
+  const selectedIdx =
+    Number(
+      await promptAsync(`Select template 1-${templateNames.length}`, "none")
+    ) - 1;
+
+  if (Number.isNaN(selectedIdx) || !templateNames[selectedIdx]) {
+    return -1;
+  } else {
+    return selectedIdx;
+  }
+};
+
+module.exports = selectTemplateIdx;

--- a/src/util/titleize.js
+++ b/src/util/titleize.js
@@ -1,0 +1,41 @@
+const capitalize = require("./capitalize");
+
+const special = new Set();
+const specialArray = [
+  'and',
+  'or',
+  'to',
+  'of',
+  'for',
+  'in',
+  'the',
+  'a',
+  'an',
+  'nor',
+  'but',
+];
+
+specialArray.forEach((word) => special.add(word));
+
+const titleize = (str) => {
+  if (str === '') return '';
+
+  const words = str.split(/\s/);
+  const middleWords = words.slice(1, words.length - 1);
+  const firstWord = words[0];
+  const lastWord = words[words.length - 1];
+  const resultWords = [];
+
+  resultWords.push(capitalize(firstWord));
+
+  middleWords.forEach((word) => {
+    word = word.toLowerCase();
+    resultWords.push(special.has(word) ? word : capitalize(word));
+  });
+
+  resultWords.push(capitalize(lastWord));
+
+  return resultWords.join(' ');
+};
+
+module.exports = titleize;

--- a/src/util/titleize.js
+++ b/src/util/titleize.js
@@ -21,6 +21,10 @@ const titleize = (str) => {
   if (str === '') return '';
 
   const words = str.split(/\s/);
+  if (words.length === 1) {
+    return capitalize(words[0]);
+  }
+
   const middleWords = words.slice(1, words.length - 1);
   const firstWord = words[0];
   const lastWord = words[words.length - 1];

--- a/src/util/titleize.js
+++ b/src/util/titleize.js
@@ -2,23 +2,23 @@ const capitalize = require("./capitalize");
 
 const special = new Set();
 const specialArray = [
-  'and',
-  'or',
-  'to',
-  'of',
-  'for',
-  'in',
-  'the',
-  'a',
-  'an',
-  'nor',
-  'but',
+  "and",
+  "or",
+  "to",
+  "of",
+  "for",
+  "in",
+  "the",
+  "a",
+  "an",
+  "nor",
+  "but",
 ];
 
 specialArray.forEach((word) => special.add(word));
 
 const titleize = (str) => {
-  if (str === '') return '';
+  if (str === "") return "";
 
   const words = str.split(/\s/);
   if (words.length === 1) {
@@ -39,7 +39,7 @@ const titleize = (str) => {
 
   resultWords.push(capitalize(lastWord));
 
-  return resultWords.join(' ');
+  return resultWords.join(" ");
 };
 
 module.exports = titleize;


### PR DESCRIPTION
When running `maestro new <PROJECT_NAME>`,  the user is prompted to select a template (options read from `~/.maestro/templates`) to base their new project off of. If the user presses `<return>` at the prompt, it defaults to no template. If the user enters an invalid option, it defaults to no template.

For reference, the selecting template prompt looks like this (`▌` = cursor):

```
Select a template to base your project off of (defaults to no template)
-----------------------------------------------------------------------
  [1] Example workflow (example-workflow)
  [2] Microservice routing (microservice-routing)
  [3] Query third party api (query-third-party-api)
  [4] Video transcoding (video-transcoding)
-----------------------------------------------------------------------
Select template 1-4 [none] ▌
```

If a project is created with the `--template=<TEMPLATE_NAME>`/`--template <TEMPLATE_NAME>` flag, the prompting to select a template is skipped and the project is created with the specified template. If the provided template name is invalid, the user is prompted to select a template as described in the first paragraph.

If a project is created with the `--no-template`/`-n` flag, then the user is not prompted to select a template and an empty project is created.

When a project is created, these main steps happen (note that green parts are substeps of a bigger steps):

![maestro-new-workflow (2)](https://user-images.githubusercontent.com/42946880/89716620-b0d99900-d96b-11ea-9bdf-bfea770d2b83.png)

Closes #43.