### PR TITLE
Get templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ To use, you must have the [AWS CLI][aws-cli] installed and set up.
   - `aws-sdk`
 - `zip` command line utility
 - [AWS CLI][aws-cli]
+- `git` version control system
 
 ## Development Assumptions
 

--- a/bin/maestro.js
+++ b/bin/maestro.js
@@ -10,6 +10,7 @@ const argv = minimist(process.argv.slice(2), {
 });
 const deploy = require('../src/commands/deploy');
 const teardown = require('../src/commands/teardown');
+const getTemplates = require('../src/commands/getTemplates');
 
 switch(argv._[0]) {
   case 'deploy':
@@ -17,6 +18,10 @@ switch(argv._[0]) {
     break;
   case 'teardown':
     teardown(argv);
+    break;
+  // TODO: perhaps `maestro get-templates` should be called as part of the `maestro config` command? If so, should we still leave `get-templates` as a top level sub-command?
+  case 'get-templates':
+    getTemplates();
     break;
   default:
     console.log(`See documentation for commands (i.e. deploy, teardown).\n https://github.com/maestro-framework/maestro`);

--- a/src/aws/services.js
+++ b/src/aws/services.js
@@ -5,7 +5,7 @@ AWS.config.logger = console;
 
 const apiVersion = "latest";
 const region = JSON.parse(
-  fs.readFileSync(homedir + "/.config/maestro/aws_account_info.json")
+  fs.readFileSync(homedir + "/.maestro/aws_account_info.json")
 ).region;
 
 const iam = new AWS.IAM();

--- a/src/commands/getTemplates.js
+++ b/src/commands/getTemplates.js
@@ -1,0 +1,32 @@
+const fs = require("fs");
+const os = require("os");
+const childProcess = require("child_process");
+
+const repo = "https://github.com/maestro-framework/maestro-templates";
+const templatesDir = `${os.homedir()}/.maestro/templates`;
+const alreadyExistsMsg = `The default Maestro templates already exist at ${templatesDir}`;
+const creationMsg = `The default Maestro templates have been created at ${templatesDir}`;
+
+const areTemplatesExisting = () => {
+  return fs.existsSync(templatesDir);
+};
+
+const downloadTemplates = () => {
+  const temporaryDir = fs.mkdtempSync("tmp");
+
+  childProcess.execSync(`mkdir ${templatesDir}`);
+  childProcess.execSync(`git clone -q ${repo} ${temporaryDir}`);
+  childProcess.execSync(`mv ${temporaryDir}/templates/* ${templatesDir}`);
+  childProcess.execSync(`rm -rf ${temporaryDir}`);
+};
+
+const getTemplates = () => {
+  if (areTemplatesExisting()) {
+    console.log(alreadyExistsMsg);
+  } else {
+    downloadTemplates();
+    console.log(creationMsg);
+  }
+};
+
+module.exports = getTemplates;


### PR DESCRIPTION
Adds a `maestro get-templates` sub-command:
- If the default Maestro templates already exist at `~/.maestro/templates`, it will inform the user of this.
- Otherwise, it clones the [maestro-framework/maestro-templates](https://github.com/maestro-framework/maestro-templates) repo into a temporary directory, moves the Maestro default templates into `~/.maestro/templates`, and deletes the temporary directory.

Lists `git` as a Maestro dependency in the top level README.

Note: this PR merges this branch into `npm-packaging`, **NOT** `master`
Note: need to determine if we want this command to be run as part of `maestro config` in some way.

Closes #42