### PR TITLE
Config command validation

### DIFF
--- a/src/commands/config.js
+++ b/src/commands/config.js
@@ -1,6 +1,7 @@
 const fs = require("fs");
 const os = require("os");
 const promptAsync = require("../util/promptAsync");
+const AWSRegions = require("../config/AWSRegions");
 
 const hiddenMaestroDirPath = () => {
   const homedir = os.homedir();
@@ -18,6 +19,8 @@ const createHiddenMaestroDir = () => {
 };
 
 const asyncPromptForAccountInfo = async () => {
+  // TODO: add validation for account #
+  //    12 digits, no separator
   const accountNumber = await promptAsync(
     "Please enter your AWS Account Number: "
   );

--- a/src/commands/config.js
+++ b/src/commands/config.js
@@ -4,20 +4,26 @@ const configDir = require("../util/configDir");
 const promptAsync = require("../util/promptAsync");
 const AWSRegions = require("../config/AWSRegions");
 
-// const hiddenMaestroDirPath = () => {
-//   const homedir = os.homedir();
-//   const dir = "/.maestro";
-
-//   return homedir + dir;
-// };
-
 const createHiddenMaestroDir = () => {
   if (!fs.existsSync(configDir)) {
     fs.mkdirSync(configDir);
   }
 };
 
-const promptForValidRegion = async () => {
+const asyncPromptForValidAccountNumber = async () => {
+  const isValidAccountLengthRegex = /\d{12}/;
+  let inputAcctNum = 'invalidAcctNum';
+
+  while(!isValidAccountLengthRegex.test(inputAcctNum)) {
+    inputAcctNum = await promptAsync(
+      "Please enter your AWS Account Number: "
+    );
+  }
+
+  return inputAcctNum;
+};
+
+const asyncPromptForValidRegion = async () => {
   let inputRegion = 'invalid-region';
 
   while (!AWSRegions.includes(inputRegion)) {
@@ -30,12 +36,8 @@ const promptForValidRegion = async () => {
 };
 
 const asyncPromptForAccountInfo = async () => {
-  // TODO: add validation for account #
-  //    12 digits, no separator
-  const accountNumber = await promptAsync(
-    "Please enter your AWS Account Number: "
-  );
-  const region = await promptForValidRegion();
+  const accountNumber = await asyncPromptForValidAccountNumber();
+  const region = await asyncPromptForValidRegion();
 
   return { accountNumber, region };
 };

--- a/src/commands/config.js
+++ b/src/commands/config.js
@@ -18,15 +18,25 @@ const createHiddenMaestroDir = () => {
   }
 };
 
+const promptForValidRegion = async () => {
+  let inputRegion = 'invalid-region';
+
+  while (!AWSRegions.includes(inputRegion)) {
+    inputRegion = await promptAsync(
+      "Please enter the region for you AWS services (e.g. us-west-2): "
+    );
+  }
+
+  return inputRegion;
+};
+
 const asyncPromptForAccountInfo = async () => {
   // TODO: add validation for account #
   //    12 digits, no separator
   const accountNumber = await promptAsync(
     "Please enter your AWS Account Number: "
   );
-  const region = await promptAsync(
-    "Please enter the region for you AWS services (e.g. us-west-2): "
-  );
+  const region = await promptForValidRegion();
 
   return { accountNumber, region };
 };

--- a/src/commands/config.js
+++ b/src/commands/config.js
@@ -28,7 +28,7 @@ const asyncPromptForValidRegion = async () => {
 
   while (!AWSRegions.includes(inputRegion)) {
     inputRegion = await promptAsync(
-      "Please enter the region for you AWS services (e.g. us-west-2): "
+      "Please enter the region for your AWS services (e.g. us-west-2): "
     );
   }
 

--- a/src/commands/config.js
+++ b/src/commands/config.js
@@ -1,20 +1,19 @@
 const fs = require("fs");
 const os = require("os");
+const configDir = require("../util/configDir");
 const promptAsync = require("../util/promptAsync");
 const AWSRegions = require("../config/AWSRegions");
 
-const hiddenMaestroDirPath = () => {
-  const homedir = os.homedir();
-  const dir = "/.maestro";
+// const hiddenMaestroDirPath = () => {
+//   const homedir = os.homedir();
+//   const dir = "/.maestro";
 
-  return homedir + dir;
-};
+//   return homedir + dir;
+// };
 
 const createHiddenMaestroDir = () => {
-  const hiddenDirPath = hiddenMaestroDirPath();
-
-  if (!fs.existsSync(hiddenDirPath)) {
-    fs.mkdirSync(hiddenDirPath);
+  if (!fs.existsSync(configDir)) {
+    fs.mkdirSync(configDir);
   }
 };
 
@@ -42,7 +41,7 @@ const asyncPromptForAccountInfo = async () => {
 };
 
 const writeAccountInfoFile = (accountNumAndRegion) => {
-  const accountInfoFilePath = hiddenMaestroDirPath() + "/aws_account_info.json";
+  const accountInfoFilePath = configDir + "/aws_account_info.json";
   fs.writeFileSync(accountInfoFilePath, JSON.stringify(accountNumAndRegion));
 };
 

--- a/src/config/AWSRegions.js
+++ b/src/config/AWSRegions.js
@@ -1,0 +1,27 @@
+const AWSRegions = [
+    "us-east-2",
+    "us-east-1",
+    "us-west-1",
+    "us-west-2",
+    "af-south-1",
+    "ap-east-1",
+    "ap-south-1",
+    "ap-northeast-3",
+    "ap-northeast-2",
+    "ap-southeast-1",
+    "ap-southeast-2",
+    "ap-northeast-1",
+    "ca-central-1",
+    "cn-north-1",
+    "cn-northwest-1",
+    "eu-central-1",
+    "eu-west-1",
+    "eu-west-2",
+    "eu-south-1",
+    "eu-west-3",
+    "eu-north-1",
+    "me-south-1",
+    "sa-east-1"
+  ]
+
+module.exports = AWSRegions;


### PR DESCRIPTION
Added validation for prompting the user for a region as well as account number. The user must enter a valid 12 digit number for the account; otherwise, they are re-prompted. Likewise, the region they enter must be a valid region that is among the AWS regions in `src/config/AWSRegiosn`, or they are re-prompted.

Also, removed `hiddenMaestroDirPath` and read in `src/util/configDir` instead to replace references.

Fixes #55 