### PR TITLE
Create account info util

### DIFF
--- a/src/aws/services.js
+++ b/src/aws/services.js
@@ -1,15 +1,9 @@
-const fs = require("fs");
-const homedir = require("os").homedir();
 const AWS = require("aws-sdk");
-const awsAcccountInfoDir = "/.maestro/aws_account_info.json";
-AWS.config.logger = console;
+const { region } = require("../util/awsAccountInfo");
 
 const apiVersion = "latest";
-let region;
 
-if (fs.existsSync(homedir + awsAcccountInfoDir)) {
-  region = JSON.parse(fs.readFileSync(homedir + awsAcccountInfoDir)).region;
-}
+AWS.config.logger = console;
 
 const iam = new AWS.IAM();
 const lambda = new AWS.Lambda({ apiVersion, region });

--- a/src/commands/config.js
+++ b/src/commands/config.js
@@ -1,5 +1,4 @@
 const fs = require("fs");
-const os = require("os");
 const configDir = require("../util/configDir");
 const promptAsync = require("../util/promptAsync");
 const AWSRegions = require("../config/AWSRegions");

--- a/src/commands/newProject.js
+++ b/src/commands/newProject.js
@@ -1,4 +1,3 @@
-const childProcess = require("child_process");
 const fs = require("fs");
 
 const configDir = require("../util/configDir");

--- a/src/util/awsAccountInfo.js
+++ b/src/util/awsAccountInfo.js
@@ -1,0 +1,8 @@
+const fs = require("fs");
+const configDir = require("./configDir.js");
+
+const { accountNumber, region } = JSON.parse(
+  fs.readFileSync(`${configDir}/aws_account_info.json`)
+);
+
+module.exports = { accountNumber, region };


### PR DESCRIPTION
I made the below commits. In summary, I saw that we could extract awsAccountInfo into its own utility file, and, in the process, did a bit of refactoring on `services.js` and `generateStateMachineParams.js`. I also removed a couple of extraneous `require` calls.

I've tested everything and it seems to be working fine, but you may want to do some testing yourself.

Remove extraneous `require("os") from `config.js`
Extract `awsAccountInfo` to own file
Remove extraneous `childProcess` from `newProject.js`
Refactor services.js
Refactor generateStateMachineParams.js