### PR TITLE
Add ASL validation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "dependencies": {
+    "asl-validator": "^1.7.1",
     "aws-sdk": "^2.724.0",
     "minimist": "^1.2.5"
   },

--- a/src/aws/step-function/createStepFunction.js
+++ b/src/aws/step-function/createStepFunction.js
@@ -1,7 +1,16 @@
+const aslValidator = require("asl-validator");
 const { stepFunctions } = require("../services");
 
 const createStepFunction = (params) => {
-  return stepFunctions.createStateMachine(params).promise();
+  const { definition } = params;
+  const { isValid, errorsText } = aslValidator(JSON.parse(definition));
+
+  if (isValid) {
+    return stepFunctions.createStateMachine(params).promise();
+  } else {
+    console.error("✕ State machine definition is invalid:", errorsText("\n"));
+    throw new Error();
+  }
 };
 
 module.exports = createStepFunction;

--- a/src/aws/step-function/generateStateMachineParams.js
+++ b/src/aws/step-function/generateStateMachineParams.js
@@ -1,4 +1,3 @@
-const aslValidator = require("asl-validator");
 const fs = require("fs");
 const { iam } = require("../services");
 const workflowName = require("../../util/workflowName");
@@ -8,18 +7,12 @@ const generateStateMachineParams = async (roleName) => {
   const role = await iam.getRole({ RoleName: roleName }).promise();
   const aslTemplate = fs.readFileSync("definition.asl.json").toString();
   const definition = replacePlaceholders(aslTemplate);
-  const { isValid, errorsText } = aslValidator(JSON.parse(definition));
 
-  if (isValid) {
-    return {
-      definition,
-      name: workflowName,
-      roleArn: role.Role.Arn,
-    };
-  } else {
-    console.error("✕ State machine definition is invalid:", errorsText("\n"));
-    return;
-  }
+  return {
+    definition,
+    name: workflowName,
+    roleArn: role.Role.Arn,
+  };
 };
 
 module.exports = generateStateMachineParams;

--- a/src/util/replacePlaceholders.js
+++ b/src/util/replacePlaceholders.js
@@ -1,8 +1,8 @@
 const { accountNumber, region } = require("./awsAccountInfo");
 const workflowName = require("./workflowName");
 
-const replacePlaceholders = (definitionTemplate) => {
-  let definition = definitionTemplate;
+const replacePlaceholders = (aslTemplate) => {
+  let definition = aslTemplate;
 
   definition = definition.replace(/REGION/g, region);
   definition = definition.replace(/ACCOUNT_ID/g, accountNumber);

--- a/src/util/replacePlaceholders.js
+++ b/src/util/replacePlaceholders.js
@@ -1,0 +1,14 @@
+const { accountNumber, region } = require("./awsAccountInfo");
+const workflowName = require("./workflowName");
+
+const replacePlaceholders = (definitionTemplate) => {
+  let definition = definitionTemplate;
+
+  definition = definition.replace(/REGION/g, region);
+  definition = definition.replace(/ACCOUNT_ID/g, accountNumber);
+  definition = definition.replace(/WORKFLOW_NAME/g, workflowName);
+
+  return definition;
+};
+
+module.exports = replacePlaceholders;


### PR DESCRIPTION
I've added the npm module `asl-validator` to the project.

Now, whenever the `generateStateMachineParams` function is invoked and the state machine definition is invalid, the proper errors will be logged to the console.