### PR TITLE
Add a `help` command

### DIFF
--- a/bin/maestro.js
+++ b/bin/maestro.js
@@ -3,44 +3,42 @@
 const minimist = require("minimist");
 
 const argv = minimist(process.argv.slice(2), {
-  boolean: ["force", "n"],
+  boolean: ["force", "n", "help"],
   string: ["roles", "template"],
   alias: {
     f: "force",
     t: "template",
+    h: "help",
   },
   default: {
     roles: "",
   },
 });
 
-const defaultMsg = `See man pages for commands:
-maestro(1)
-maestro-config(1)
-maestro-deploy(1)
-maestro-teardown(1)
-maestro-new(1)
-maestro-get-templates(1)`;
-
-switch (argv._[0]) {
-  case "config":
-    require("../src/commands/config")();
-    break;
-  case "deploy":
-    require("../src/commands/deploy")();
-    break;
-  case "teardown":
-    require("../src/commands/teardown")(argv);
-    break;
-  case "new":
-    require("../src/commands/newProject")(argv);
-    break;
-  case "get-templates":
-    require("../src/commands/getTemplates")();
-    break;
-  case "help":
-    require("../src/commands/help")(argv);
-    break;
-  default:
-    console.log(defaultMsg);
+if (argv.help) {
+  require("../src/commands/help")(argv._[0]);
+} else {
+  switch (argv._[0]) {
+    case "config":
+      require("../src/commands/config")();
+      break;
+    case "deploy":
+      require("../src/commands/deploy")();
+      break;
+    case "teardown":
+      require("../src/commands/teardown")(argv);
+      break;
+    case "new":
+      require("../src/commands/newProject")(argv);
+      break;
+    case "get-templates":
+      require("../src/commands/getTemplates")();
+      break;
+    case "help":
+      require("../src/commands/help")(argv._[1]);
+      break;
+    default:
+      require("../src/commands/help")();
+      break;
+  }
 }

--- a/bin/maestro.js
+++ b/bin/maestro.js
@@ -38,6 +38,9 @@ switch (argv._[0]) {
   case "get-templates":
     require("../src/commands/getTemplates")();
     break;
+  case "help":
+    require("../src/commands/help")(argv);
+    break;
   default:
     console.log(defaultMsg);
 }

--- a/doc/man/maestro-help.1
+++ b/doc/man/maestro-help.1
@@ -14,12 +14,6 @@ maestro \- display help information about maestro or maestro command
 .B maestro
 [\fIcommand\fR] \fB\-h\fR|\fB\-\-help\fR
 
-.SH DESCRIPTION
-
-.SH OPTIONS
-
-.SH NOTES
-
 .SH BUGS
 
 .PP
@@ -29,6 +23,46 @@ the GitHub Issues page
 .UE .
 
 .SH EXAMPLE
+
+.SS Using the --help flag
+
+.PP
+This shows an example of running
+.IR "maestro <subcommand> --help" .
+
+.PP
+.RS
+.EX
+$ \fBmaestro config --help\fR
+maestro-config: \fImaestro config\fR
+    Set up or alter your Maestro configuration files.
+
+    Run \fImaestro config\fR to set the global config values of AWS account number and
+    region.
+
+    See manual page \fBmaestro-config(1)\fR for more information.
+.EE
+.RE
+
+.SS Using the help subcommand
+
+.PP
+This shows an example of running
+.IR "maestro help <subcommand>" .
+
+.PP
+.RS
+.EX
+$ \fBmaestro help config\fR
+maestro-config: \fImaestro config\fR
+    Set up or alter your Maestro configuration files.
+
+    Run \fImaestro config\fR to set the global config values of AWS account number and
+    region.
+
+    See manual page \fBmaestro-config(1)\fR for more information.
+.EE
+.RE
 
 .SH SEE ALSO
 

--- a/src/commands/help.js
+++ b/src/commands/help.js
@@ -14,16 +14,16 @@ const codes = {
   white: "\033[37m",
 };
 
-const genericHelpMsg = `Run \`${codes.blue}maestro help${codes.reset} ${
-  codes.italic + codes.underline + codes.red
+const genericHelpMsg = `Run \`${codes.italic + codes.blue}maestro help${codes.reset} ${
+  codes.italic + codes.bold + codes.red
 }command${codes.reset}\` to get help specific to a subcommand.`;
 
-const configMsg = `maestro-config: ${codes.blue + codes.italic}maestro config${
+const configMsg = `maestro-config: ${codes.italic + codes.blue}maestro config${
   codes.reset
 }
     Set up or alter your Maestro configuration files.
 
-    Run ${codes.blue + codes.italic}maestro config${
+    Run ${codes.italic + codes.blue}maestro config${
   codes.reset
 } to set the global config values of AWS account number and
     region.
@@ -32,12 +32,12 @@ const configMsg = `maestro-config: ${codes.blue + codes.italic}maestro config${
   codes.reset
 } for more information.`;
 
-const deployMsg = `maestro-deploy: ${codes.blue + codes.italic}maestro deploy${
+const deployMsg = `maestro-deploy: ${codes.italic + codes.blue}maestro deploy${
   codes.reset
 }
     Deploy a full AWS Step Functions workflow with AWS Lambdas.
 
-    Run ${codes.blue + codes.italic}maestro deploy${
+    Run ${codes.italic + codes.blue}maestro deploy${
   codes.reset
 } inside a Maestro project to quickly deploy all the
     project's resources including AWS IAM Roles, AWS Lambdas, and the AWS Step
@@ -48,11 +48,11 @@ const deployMsg = `maestro-deploy: ${codes.blue + codes.italic}maestro deploy${
 } for more information.`;
 
 const teardownMsg = `maestro-teardown: ${
-  codes.blue + codes.italic
+  codes.italic + codes.blue
 }maestro teardown${codes.reset}
     Teardown an existing Maestro project.
 
-    Run ${codes.blue + codes.italic}maestro teardown${
+    Run ${codes.italic + codes.blue}maestro teardown${
   codes.reset
 } inside a Maestro project to quickly tear down all
     the project's resources including AWS Lambdas, the AWS Step Functions state
@@ -62,13 +62,13 @@ const teardownMsg = `maestro-teardown: ${
   codes.reset
 } for more information.`;
 
-const newMsg = `maestro-new: ${codes.blue + codes.italic}maestro new${
+const newMsg = `maestro-new: ${codes.italic + codes.blue}maestro new${
   codes.reset
-} ${codes.italic + codes.underline + codes.red}project_name${codes.reset}
+} ${codes.italic + codes.bold + codes.red}project_name${codes.reset}
     Create a new Maestro project.
 
-    Run ${codes.blue + codes.italic}maestro new${codes.reset} ${
-  codes.italic + codes.underline + codes.red
+    Run ${codes.italic + codes.blue}maestro new${codes.reset} ${
+  codes.italic + codes.bold + codes.red
 }project_name${codes.reset} to create a new maestro project with the
     given project name.
     When this command is executed a prompt is displayed listing all of the
@@ -78,7 +78,18 @@ const newMsg = `maestro-new: ${codes.blue + codes.italic}maestro new${
   codes.reset
 } for more information.`;
 
-const getTemplatesMsg = `"Get templates" help message`;
+const getTemplatesMsg = `maestro-get-templates: ${
+  codes.italic + codes.blue
+}maestro get-templates${codes.reset}
+    Fetch and install the default Maestro templates.
+
+    Run ${codes.italic + codes.blue}maestro get-templates${codes.reset} to fetch and install the default Maestro
+    templates from the ${codes.yellow}⟨${codes.green + codes.underline}https://github.com/maestro-framework/maestro-templates${codes.reset + codes.yellow}⟩${codes.reset}
+    git repository.
+
+    See manual page ${codes.yellow + codes.bold}maestro-get-templates(1)${
+  codes.reset
+} for more information.`;
 
 const helpMsg = genericHelpMsg;
 

--- a/src/commands/help.js
+++ b/src/commands/help.js
@@ -1,3 +1,39 @@
-const help = () => {};
+const genericHelpMsg  = "\"Generic help\" help message";
+const configMsg       = "\"Config\" help message";
+const deployMsg       = "\"Deploy\" help message";
+const teardownMsg     = "\"Teardown\" help message";
+const newMsg          = "\"New\" help message";
+const getTemplatesMsg = "\"Get templates\" help message";
+const helpMsg         = "\"Help\" help message";
+const defaultMsg      = "\"Default\" help message";
+
+const help = (argv) => {
+  switch (argv._[1]) {
+    case undefined:
+      console.log(genericHelpMsg);
+      break;
+    case "config":
+      console.log(configMsg);
+      break;
+    case "deploy":
+      console.log(deployMsg);
+      break;
+    case "teardown":
+      console.log(teardownMsg);
+      break;
+    case "new":
+      console.log(newMsg);
+      break;
+    case "get-templates":
+      console.log(getTemplatesMsg);
+      break;
+    case "help":
+      console.log(helpMsg);
+      break;
+    default:
+      console.log(defaultMsg);
+      break;
+  }
+};
 
 module.exports = help;

--- a/src/commands/help.js
+++ b/src/commands/help.js
@@ -1,55 +1,88 @@
 const codes = {
-  reset:     "\033[m",
-  bold:      "\033[1m",
-  faint:     "\033[2m",
-  italic:    "\033[3m",
+  reset: "\033[m",
+  bold: "\033[1m",
+  faint: "\033[2m",
+  italic: "\033[3m",
   underline: "\033[4m",
-  black:     "\033[30m",
-  red:       "\033[31m",
-  green:     "\033[32m",
-  yellow:    "\033[33m",
-  blue:      "\033[34m",
-  magenta:   "\033[35m",
-  cyan:      "\033[36m",
-  white:     "\033[37m",
+  black: "\033[30m",
+  red: "\033[31m",
+  green: "\033[32m",
+  yellow: "\033[33m",
+  blue: "\033[34m",
+  magenta: "\033[35m",
+  cyan: "\033[36m",
+  white: "\033[37m",
 };
 
-const genericHelpMsg  = `Run \`${codes.blue}maestro help${codes.reset} ${codes.italic + codes.underline + codes.red}command${codes.reset}\` to get help specific to a subcommand.`;
-const configMsg       = `maestro-config: ${codes.blue + codes.italic}maestro config${codes.reset}
+const genericHelpMsg = `Run \`${codes.blue}maestro help${codes.reset} ${
+  codes.italic + codes.underline + codes.red
+}command${codes.reset}\` to get help specific to a subcommand.`;
+
+const configMsg = `maestro-config: ${codes.blue + codes.italic}maestro config${
+  codes.reset
+}
     Set up or alter your Maestro configuration files.
 
-    Run ${codes.blue + codes.italic}maestro config${codes.reset} to set the global config values of AWS account number and
+    Run ${codes.blue + codes.italic}maestro config${
+  codes.reset
+} to set the global config values of AWS account number and
     region.
 
-    See manual page ${codes.yellow + codes.bold}maestro-config(1)${codes.reset} for more information.`;
-const deployMsg       = `maestro-deploy: ${codes.blue + codes.italic}maestro deploy${codes.reset}
+    See manual page ${codes.yellow + codes.bold}maestro-config(1)${
+  codes.reset
+} for more information.`;
+
+const deployMsg = `maestro-deploy: ${codes.blue + codes.italic}maestro deploy${
+  codes.reset
+}
     Deploy a full AWS Step Functions workflow with AWS Lambdas.
 
-    Run ${codes.blue + codes.italic}maestro deploy${codes.reset} inside a Maestro project to quickly deploy all the
+    Run ${codes.blue + codes.italic}maestro deploy${
+  codes.reset
+} inside a Maestro project to quickly deploy all the
     project's resources including AWS IAM Roles, AWS Lambdas, and the AWS Step
     Functions state machine.
 
-    See manual page ${codes.yellow + codes.bold}maestro-deploy(1)${codes.reset} for more information.`;
-const teardownMsg     = `maestro-teardown: ${codes.blue + codes.italic}maestro teardown${codes.reset}
+    See manual page ${codes.yellow + codes.bold}maestro-deploy(1)${
+  codes.reset
+} for more information.`;
+
+const teardownMsg = `maestro-teardown: ${
+  codes.blue + codes.italic
+}maestro teardown${codes.reset}
     Teardown an existing Maestro project.
 
-    Run ${codes.blue + codes.italic}maestro teardown${codes.reset} inside a Maestro project to quickly tear down all
+    Run ${codes.blue + codes.italic}maestro teardown${
+  codes.reset
+} inside a Maestro project to quickly tear down all
     the project's resources including AWS Lambdas, the AWS Step Functions state
     machine, and optionally AWS IAM Roles.
 
-    See manual page ${codes.yellow + codes.bold}maestro-teardown(1)${codes.reset} for more information.`;
-const newMsg          = `maestro-new: ${codes.blue + codes.italic}maestro new${codes.reset} ${codes.italic + codes.underline + codes.red}project_name${codes.reset}
+    See manual page ${codes.yellow + codes.bold}maestro-teardown(1)${
+  codes.reset
+} for more information.`;
+
+const newMsg = `maestro-new: ${codes.blue + codes.italic}maestro new${
+  codes.reset
+} ${codes.italic + codes.underline + codes.red}project_name${codes.reset}
     Create a new Maestro project.
 
-    Run ${codes.blue + codes.italic}maestro new${codes.reset} ${codes.italic + codes.underline + codes.red}project_name${codes.reset} to create a new maestro project with the
+    Run ${codes.blue + codes.italic}maestro new${codes.reset} ${
+  codes.italic + codes.underline + codes.red
+}project_name${codes.reset} to create a new maestro project with the
     given project name.
     When this command is executed a prompt is displayed listing all of the
     available templates on which to base this new project.
 
-    See manual page ${codes.yellow + codes.bold}maestro-new(1)${codes.reset} for more information.`;
+    See manual page ${codes.yellow + codes.bold}maestro-new(1)${
+  codes.reset
+} for more information.`;
+
 const getTemplatesMsg = `"Get templates" help message`;
-const helpMsg         = genericHelpMsg;
-const defaultMsg      = genericHelpMsg;
+
+const helpMsg = genericHelpMsg;
+
+const defaultMsg = genericHelpMsg;
 
 const help = (argv) => {
   switch (argv._[1]) {

--- a/src/commands/help.js
+++ b/src/commands/help.js
@@ -4,6 +4,7 @@ const codes = {
   faint:     "\033[2m",
   italic:    "\033[3m",
   underline: "\033[4m",
+  black:     "\033[30m",
   red:       "\033[31m",
   green:     "\033[32m",
   yellow:    "\033[33m",
@@ -14,7 +15,11 @@ const codes = {
 };
 
 const genericHelpMsg  = `Run \`${codes.blue}maestro help${codes.reset} ${codes.italic + codes.underline + codes.red}command${codes.reset}\` to get help specific to a subcommand.`;
-const configMsg       = `"Config" help message`;
+const configMsg       = `maestro-config: ${codes.blue + codes.italic}maestro config${codes.reset}
+    Set up or alter your Maestro configuration files.
+
+    Run ${codes.blue + codes.italic}maestro config${codes.reset} to set the global config values of AWS account number and region.
+    See manual page ${codes.yellow + codes.bold}maestro-config(1)${codes.reset} for more information.`;
 const deployMsg       = `"Deploy" help message`;
 const teardownMsg     = `"Teardown" help message`;
 const newMsg          = `"New" help message`;

--- a/src/commands/help.js
+++ b/src/commands/help.js
@@ -1,8 +1,3 @@
-/*
-TODO:
-- add flag usage for commands that need it
-*/
-
 const codes = {
   reset: "\033[m",
   bold: "\033[1m",

--- a/src/commands/help.js
+++ b/src/commands/help.js
@@ -31,14 +31,22 @@ const deployMsg       = `maestro-deploy: ${codes.blue + codes.italic}maestro dep
 
     See manual page ${codes.yellow + codes.bold}maestro-deploy(1)${codes.reset} for more information.`;
 const teardownMsg     = `maestro-teardown: ${codes.blue + codes.italic}maestro teardown${codes.reset}
-    Teardown an existing maestro project.
+    Teardown an existing Maestro project.
 
     Run ${codes.blue + codes.italic}maestro teardown${codes.reset} inside a Maestro project to quickly tear down all
     the project's resources including AWS Lambdas, the AWS Step Functions state
     machine, and optionally AWS IAM Roles.
 
     See manual page ${codes.yellow + codes.bold}maestro-teardown(1)${codes.reset} for more information.`;
-const newMsg          = `"New" help message`;
+const newMsg          = `maestro-new: ${codes.blue + codes.italic}maestro new${codes.reset} ${codes.italic + codes.underline + codes.red}project_name${codes.reset}
+    Create a new Maestro project.
+
+    Run ${codes.blue + codes.italic}maestro new${codes.reset} ${codes.italic + codes.underline + codes.red}project_name${codes.reset} to create a new maestro project with the
+    given project name.
+    When this command is executed a prompt is displayed listing all of the
+    available templates on which to base this new project.
+
+    See manual page ${codes.yellow + codes.bold}maestro-new(1)${codes.reset} for more information.`;
 const getTemplatesMsg = `"Get templates" help message`;
 const helpMsg         = genericHelpMsg;
 const defaultMsg      = genericHelpMsg;

--- a/src/commands/help.js
+++ b/src/commands/help.js
@@ -25,12 +25,19 @@ const configMsg       = `maestro-config: ${codes.blue + codes.italic}maestro con
 const deployMsg       = `maestro-deploy: ${codes.blue + codes.italic}maestro deploy${codes.reset}
     Deploy a full AWS Step Functions workflow with AWS Lambdas.
 
-    Run ${codes.blue + codes.italic}maestro deploy${codes.reset} inside a Maestro project to deploy all the project's
-    resources including AWS IAM Roles, AWS Lambdas, and the AWS Step Functions
-    state machine.
+    Run ${codes.blue + codes.italic}maestro deploy${codes.reset} inside a Maestro project to quickly deploy all the
+    project's resources including AWS IAM Roles, AWS Lambdas, and the AWS Step
+    Functions state machine.
 
-    See manual page ${codes.yellow + codes.bold}maestro-config(1)${codes.reset} for more information.`;
-const teardownMsg     = `"Teardown" help message`;
+    See manual page ${codes.yellow + codes.bold}maestro-deploy(1)${codes.reset} for more information.`;
+const teardownMsg     = `maestro-teardown: ${codes.blue + codes.italic}maestro teardown${codes.reset}
+    Teardown an existing maestro project.
+
+    Run ${codes.blue + codes.italic}maestro teardown${codes.reset} inside a Maestro project to quickly tear down all
+    the project's resources including AWS Lambdas, the AWS Step Functions state
+    machine, and optionally AWS IAM Roles.
+
+    See manual page ${codes.yellow + codes.bold}maestro-teardown(1)${codes.reset} for more information.`;
 const newMsg          = `"New" help message`;
 const getTemplatesMsg = `"Get templates" help message`;
 const helpMsg         = genericHelpMsg;

--- a/src/commands/help.js
+++ b/src/commands/help.js
@@ -18,9 +18,18 @@ const genericHelpMsg  = `Run \`${codes.blue}maestro help${codes.reset} ${codes.i
 const configMsg       = `maestro-config: ${codes.blue + codes.italic}maestro config${codes.reset}
     Set up or alter your Maestro configuration files.
 
-    Run ${codes.blue + codes.italic}maestro config${codes.reset} to set the global config values of AWS account number and region.
+    Run ${codes.blue + codes.italic}maestro config${codes.reset} to set the global config values of AWS account number and
+    region.
+
     See manual page ${codes.yellow + codes.bold}maestro-config(1)${codes.reset} for more information.`;
-const deployMsg       = `"Deploy" help message`;
+const deployMsg       = `maestro-deploy: ${codes.blue + codes.italic}maestro deploy${codes.reset}
+    Deploy a full AWS Step Functions workflow with AWS Lambdas.
+
+    Run ${codes.blue + codes.italic}maestro deploy${codes.reset} inside a Maestro project to deploy all the project's
+    resources including AWS IAM Roles, AWS Lambdas, and the AWS Step Functions
+    state machine.
+
+    See manual page ${codes.yellow + codes.bold}maestro-config(1)${codes.reset} for more information.`;
 const teardownMsg     = `"Teardown" help message`;
 const newMsg          = `"New" help message`;
 const getTemplatesMsg = `"Get templates" help message`;

--- a/src/commands/help.js
+++ b/src/commands/help.js
@@ -1,6 +1,5 @@
 /*
 TODO:
-- create man page for maestro-help(1)
 - add flag usage for commands that need it
 */
 

--- a/src/commands/help.js
+++ b/src/commands/help.js
@@ -50,7 +50,9 @@ const deployMsg = `maestro-deploy: ${codes.italic + codes.blue}maestro deploy${
 
 const teardownMsg = `maestro-teardown: ${
   codes.italic + codes.blue
-}maestro teardown${codes.reset}
+}maestro teardown${codes.reset} [${
+  codes.italic + codes.bold + codes.red
+}options${codes.reset} ...]
     Teardown an existing Maestro project.
 
     Run ${codes.italic + codes.blue}maestro teardown${
@@ -58,6 +60,14 @@ const teardownMsg = `maestro-teardown: ${
 } inside a Maestro project to quickly tear down all
     the project's resources including AWS Lambdas, the AWS Step Functions state
     machine, and optionally AWS IAM Roles.
+
+    Options:
+      -f, --force
+          Do not prompt for confirmation.
+
+      --roles ${codes.italic + codes.bold + codes.red}role1${codes.reset}[,${codes.italic + codes.bold + codes.red}role2${codes.reset}...],
+      --roles=${codes.italic + codes.bold + codes.red}role1${codes.reset}[,${codes.italic + codes.bold + codes.red}role2${codes.reset}...]
+          Specify the roles to be deleted in addition to the other resources.
 
     See manual page ${codes.yellow + codes.bold}maestro-teardown(1)${
   codes.reset

--- a/src/commands/help.js
+++ b/src/commands/help.js
@@ -60,8 +60,12 @@ const teardownMsg = `maestro-teardown: ${
       -f, --force
           Do not prompt for confirmation.
 
-      --roles ${codes.italic + codes.bold + codes.red}role1${codes.reset}[,${codes.italic + codes.bold + codes.red}role2${codes.reset}...],
-      --roles=${codes.italic + codes.bold + codes.red}role1${codes.reset}[,${codes.italic + codes.bold + codes.red}role2${codes.reset}...]
+      --roles ${codes.italic + codes.bold + codes.red}role1${codes.reset}[,${
+  codes.italic + codes.bold + codes.red
+}role2${codes.reset}...],
+      --roles=${codes.italic + codes.bold + codes.red}role1${codes.reset}[,${
+  codes.italic + codes.bold + codes.red
+}role2${codes.reset}...]
           Specify the roles to be deleted in addition to the other resources.
 
     See manual page ${codes.yellow + codes.bold}maestro-teardown(1)${

--- a/src/commands/help.js
+++ b/src/commands/help.js
@@ -64,6 +64,8 @@ const teardownMsg = `maestro-teardown: ${
 } for more information.`;
 
 const newMsg = `maestro-new: ${codes.italic + codes.blue}maestro new ${
+  codes.reset
+}[${codes.italic + codes.bold + codes.red}options ${codes.reset}...] ${
   codes.bold + codes.red
 }project_name${codes.reset}
     Create a new Maestro project.
@@ -74,6 +76,19 @@ const newMsg = `maestro-new: ${codes.italic + codes.blue}maestro new ${
     given project name.
     When this command is executed a prompt is displayed listing all of the
     available templates on which to base this new project.
+
+    Options:
+      -n, --no-template
+          Don't use a template for the new project.
+
+      -t ${codes.italic + codes.bold + codes.red}template_name${codes.reset},
+      --template ${codes.italic + codes.bold + codes.red}template_name${
+  codes.reset
+},
+      --template=${codes.italic + codes.bold + codes.red}template_name${
+  codes.reset
+}
+          Use a specific template for the new project.
 
     See manual page ${codes.yellow + codes.bold}maestro-new(1)${
   codes.reset

--- a/src/commands/help.js
+++ b/src/commands/help.js
@@ -1,11 +1,26 @@
-const genericHelpMsg  = "\"Generic help\" help message";
-const configMsg       = "\"Config\" help message";
-const deployMsg       = "\"Deploy\" help message";
-const teardownMsg     = "\"Teardown\" help message";
-const newMsg          = "\"New\" help message";
-const getTemplatesMsg = "\"Get templates\" help message";
-const helpMsg         = "\"Help\" help message";
-const defaultMsg      = "\"Default\" help message";
+const codes = {
+  reset:     "\033[m",
+  bold:      "\033[1m",
+  faint:     "\033[2m",
+  italic:    "\033[3m",
+  underline: "\033[4m",
+  red:       "\033[31m",
+  green:     "\033[32m",
+  yellow:    "\033[33m",
+  blue:      "\033[34m",
+  magenta:   "\033[35m",
+  cyan:      "\033[36m",
+  white:     "\033[37m",
+};
+
+const genericHelpMsg  = `Run \`${codes.blue}maestro help${codes.reset} ${codes.italic + codes.underline + codes.red}command${codes.reset}\` to get help specific to a subcommand.`;
+const configMsg       = `"Config" help message`;
+const deployMsg       = `"Deploy" help message`;
+const teardownMsg     = `"Teardown" help message`;
+const newMsg          = `"New" help message`;
+const getTemplatesMsg = `"Get templates" help message`;
+const helpMsg         = genericHelpMsg;
+const defaultMsg      = genericHelpMsg;
 
 const help = (argv) => {
   switch (argv._[1]) {

--- a/src/commands/help.js
+++ b/src/commands/help.js
@@ -1,6 +1,5 @@
 /*
 TODO:
-- add support for a `--help/-h` flag to any subcommand
 - create man page for maestro-help(1)
 - add flag usage for commands that need it
 */
@@ -117,8 +116,8 @@ const defaultMsg = `Run \`${codes.italic + codes.blue}maestro help ${
   codes.bold + codes.red
 }command${codes.reset}\` to get help specific to a subcommand.`;
 
-const help = (argv) => {
-  switch (argv._[1]) {
+const help = (command) => {
+  switch (command) {
     case undefined:
       console.log(defaultMsg);
       break;

--- a/src/commands/help.js
+++ b/src/commands/help.js
@@ -14,10 +14,6 @@ const codes = {
   white: "\033[37m",
 };
 
-const genericHelpMsg = `Run \`${codes.italic + codes.blue}maestro help${codes.reset} ${
-  codes.italic + codes.bold + codes.red
-}command${codes.reset}\` to get help specific to a subcommand.`;
-
 const configMsg = `maestro-config: ${codes.italic + codes.blue}maestro config${
   codes.reset
 }
@@ -67,8 +63,8 @@ const newMsg = `maestro-new: ${codes.italic + codes.blue}maestro new${
 } ${codes.italic + codes.bold + codes.red}project_name${codes.reset}
     Create a new Maestro project.
 
-    Run ${codes.italic + codes.blue}maestro new${codes.reset} ${
-  codes.italic + codes.bold + codes.red
+    Run ${codes.italic + codes.blue}maestro new${
+  codes.bold + codes.red
 }project_name${codes.reset} to create a new maestro project with the
     given project name.
     When this command is executed a prompt is displayed listing all of the
@@ -83,22 +79,41 @@ const getTemplatesMsg = `maestro-get-templates: ${
 }maestro get-templates${codes.reset}
     Fetch and install the default Maestro templates.
 
-    Run ${codes.italic + codes.blue}maestro get-templates${codes.reset} to fetch and install the default Maestro
-    templates from the ${codes.yellow}⟨${codes.green + codes.underline}https://github.com/maestro-framework/maestro-templates${codes.reset + codes.yellow}⟩${codes.reset}
+    Run ${codes.italic + codes.blue}maestro get-templates${
+  codes.reset
+} to fetch and install the default Maestro
+    templates from the ${codes.yellow}⟨${
+  codes.green + codes.underline
+}https://github.com/maestro-framework/maestro-templates${
+  codes.reset + codes.yellow
+}⟩${codes.reset}
     git repository.
 
     See manual page ${codes.yellow + codes.bold}maestro-get-templates(1)${
   codes.reset
 } for more information.`;
 
-const helpMsg = genericHelpMsg;
+const helpMsg = `maestro-help: ${codes.italic + codes.blue}maestro help ${
+  codes.bold + codes.red
+}command${codes.reset}
+    Display help about a specific Maestro command.
 
-const defaultMsg = genericHelpMsg;
+    Run ${codes.italic + codes.blue}maestro help ${
+  codes.bold + codes.red
+}command${codes.reset} to get help specific to a Maestro subcommand.
+
+    See manual page ${codes.yellow + codes.bold}maestro-help(1)${
+  codes.reset
+} for more information.`;
+
+const defaultMsg = `Run \`${codes.italic + codes.blue}maestro help${
+  codes.bold + codes.red
+}command${codes.reset}\` to get help specific to a subcommand.`;
 
 const help = (argv) => {
   switch (argv._[1]) {
     case undefined:
-      console.log(genericHelpMsg);
+      console.log(defaultMsg);
       break;
     case "config":
       console.log(configMsg);

--- a/src/commands/help.js
+++ b/src/commands/help.js
@@ -1,3 +1,10 @@
+/*
+TODO:
+- add support for a `--help/-h` flag to any subcommand
+- create man page for maestro-help(1)
+- add flag usage for commands that need it
+*/
+
 const codes = {
   reset: "\033[m",
   bold: "\033[1m",
@@ -58,12 +65,12 @@ const teardownMsg = `maestro-teardown: ${
   codes.reset
 } for more information.`;
 
-const newMsg = `maestro-new: ${codes.italic + codes.blue}maestro new${
-  codes.reset
-} ${codes.italic + codes.bold + codes.red}project_name${codes.reset}
+const newMsg = `maestro-new: ${codes.italic + codes.blue}maestro new ${
+  codes.bold + codes.red
+}project_name${codes.reset}
     Create a new Maestro project.
 
-    Run ${codes.italic + codes.blue}maestro new${
+    Run ${codes.italic + codes.blue}maestro new ${
   codes.bold + codes.red
 }project_name${codes.reset} to create a new maestro project with the
     given project name.
@@ -106,7 +113,7 @@ const helpMsg = `maestro-help: ${codes.italic + codes.blue}maestro help ${
   codes.reset
 } for more information.`;
 
-const defaultMsg = `Run \`${codes.italic + codes.blue}maestro help${
+const defaultMsg = `Run \`${codes.italic + codes.blue}maestro help ${
   codes.bold + codes.red
 }command${codes.reset}\` to get help specific to a subcommand.`;
 

--- a/src/commands/help.js
+++ b/src/commands/help.js
@@ -1,0 +1,3 @@
+const help = () => {};
+
+module.exports = help;


### PR DESCRIPTION
This adds a `maestro help` command that can be used like `maestro help <subcommand>` or `maestro <subcommand> --help`. Try it out!

Closes #50.
Closes #51.